### PR TITLE
feat: add exclude_paths to file index configuration

### DIFF
--- a/CLA_SIGNATURES.md
+++ b/CLA_SIGNATURES.md
@@ -4,3 +4,4 @@ Talgarr - Sebastien Graveline
 julien-boost - Julien Champoux
 GuillaumeRoss - Guillaume Ross
 c0tton-fluff - Michal Ambrozkiewicz
+tveronezi - Thiago Veronezi

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -192,10 +192,9 @@ func (s *Store) Load(ctx context.Context, input LoadInput) (*fileindex.FileIndex
 		return nil, nil
 	}
 
-	// Validate ExcludePaths match (compare expanded, sorted paths)
-	expandedExcludes := ExpandBaseDirs(input.ExcludePaths)
+	// Validate ExcludePaths match (compare fully normalized, sorted paths)
 	sortedCachedExcludes := sortedCopy(cached.Metadata.ExcludePaths)
-	sortedInputExcludes := sortedCopy(expandedExcludes)
+	sortedInputExcludes := sortedCopy(normalizeExcludePaths(input.ExcludePaths))
 	if !slicesEqual(sortedCachedExcludes, sortedInputExcludes) {
 		logger.Debug().Msg("Cache exclude paths mismatch")
 		return nil, nil
@@ -252,9 +251,9 @@ func (s *Store) Save(ctx context.Context, input SaveInput) error {
 		return fmt.Errorf("create cache directory: %w", err)
 	}
 
-	// Store expanded paths for consistent comparison on load
+	// Store expanded and normalized paths for consistent comparison on load
 	expandedDirs := ExpandBaseDirs(input.BaseDirs)
-	expandedExcludes := ExpandBaseDirs(input.ExcludePaths)
+	expandedExcludes := normalizeExcludePaths(input.ExcludePaths)
 	entries := input.Index.GetAll()
 
 	cached := CachedFileIndex{
@@ -360,10 +359,11 @@ func computeCacheKey(input cacheKeyInput) string {
 		fmt.Fprintf(h, "dir:%s\n", dir)
 	}
 
-	// Expand and sort exclude paths for consistent hashing
-	expandedExcludes := ExpandBaseDirs(input.excludePaths)
-	sort.Strings(expandedExcludes)
-	for _, p := range expandedExcludes {
+	// Normalize and sort exclude paths for consistent hashing; empty/whitespace
+	// entries are dropped so they do not affect the cache key.
+	normalizedExcludes := normalizeExcludePaths(input.excludePaths)
+	sort.Strings(normalizedExcludes)
+	for _, p := range normalizedExcludes {
 		fmt.Fprintf(h, "exclude:%s\n", p)
 	}
 
@@ -431,6 +431,24 @@ func ExpandBaseDirs(baseDirs []string) []string {
 		expanded = append(expanded, expandPath(dir))
 	}
 	return expanded
+}
+
+// normalizeExcludePaths trims whitespace, drops empty entries, and fully expands
+// and cleans each exclude path so that comparisons and cache keys are stable
+// regardless of trailing slashes, leading spaces, or path separator style.
+func normalizeExcludePaths(paths []string) []string {
+	result := make([]string, 0, len(paths))
+	for _, p := range paths {
+		trimmed := strings.TrimSpace(p)
+		if trimmed == "" {
+			continue
+		}
+		expanded := expandPath(trimmed)
+		if expanded != "" && expanded != "." {
+			result = append(result, filepath.Clean(filepath.FromSlash(expanded)))
+		}
+	}
+	return result
 }
 
 // expandPath expands home directory variables and environment variables in a path.

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -23,8 +23,8 @@ import (
 
 const (
 	// SchemaVersion is incremented when the cache format changes.
-	// Bumped to 3: added staleness detection fields (BaseDirModTimes, FileSample, TotalFileCount).
-	SchemaVersion = 3
+	// Bumped to 4: added ExcludePaths to Metadata for cache key validation.
+	SchemaVersion = 4
 	// cacheFilePrefix is the prefix for cache files
 	cacheFilePrefix = "fileindex-"
 )
@@ -33,7 +33,8 @@ const (
 type Metadata struct {
 	SchemaVersion  int       `json:"schema_version"`
 	CreatedAt      time.Time `json:"created_at"`
-	BaseDirs       []string  `json:"base_dirs"` // Stored as expanded paths
+	BaseDirs       []string  `json:"base_dirs"`     // Stored as expanded paths
+	ExcludePaths   []string  `json:"exclude_paths"` // Stored as expanded paths
 	PatternsHash   string    `json:"patterns_hash"`
 	MaxDepth       int       `json:"max_depth"`
 	FollowSymlinks bool      `json:"follow_symlinks"`
@@ -110,6 +111,7 @@ func GetCacheDir() (string, error) {
 // LoadInput holds the parameters for loading a cached file index
 type LoadInput struct {
 	BaseDirs       []string
+	ExcludePaths   []string
 	Patterns       []fileindex.Pattern
 	MaxDepth       int
 	FollowSymlinks bool
@@ -124,6 +126,7 @@ func (s *Store) Load(ctx context.Context, input LoadInput) (*fileindex.FileIndex
 
 	cacheFile := s.cacheFilePath(cacheKeyInput{
 		baseDirs:       input.BaseDirs,
+		excludePaths:   input.ExcludePaths,
 		patterns:       input.Patterns,
 		maxDepth:       input.MaxDepth,
 		followSymlinks: input.FollowSymlinks,
@@ -189,6 +192,15 @@ func (s *Store) Load(ctx context.Context, input LoadInput) (*fileindex.FileIndex
 		return nil, nil
 	}
 
+	// Validate ExcludePaths match (compare expanded, sorted paths)
+	expandedExcludes := ExpandBaseDirs(input.ExcludePaths)
+	sortedCachedExcludes := sortedCopy(cached.Metadata.ExcludePaths)
+	sortedInputExcludes := sortedCopy(expandedExcludes)
+	if !slicesEqual(sortedCachedExcludes, sortedInputExcludes) {
+		logger.Debug().Msg("Cache exclude paths mismatch")
+		return nil, nil
+	}
+
 	// Check for cache staleness
 	stalenessResult := checkStaleness(StalenessCheckInput{
 		Metadata:      cached.Metadata,
@@ -223,6 +235,7 @@ func (s *Store) Load(ctx context.Context, input LoadInput) (*fileindex.FileIndex
 // SaveInput holds the parameters for saving a file index to cache
 type SaveInput struct {
 	BaseDirs       []string
+	ExcludePaths   []string
 	Patterns       []fileindex.Pattern
 	MaxDepth       int
 	FollowSymlinks bool
@@ -241,6 +254,7 @@ func (s *Store) Save(ctx context.Context, input SaveInput) error {
 
 	// Store expanded paths for consistent comparison on load
 	expandedDirs := ExpandBaseDirs(input.BaseDirs)
+	expandedExcludes := ExpandBaseDirs(input.ExcludePaths)
 	entries := input.Index.GetAll()
 
 	cached := CachedFileIndex{
@@ -248,6 +262,7 @@ func (s *Store) Save(ctx context.Context, input SaveInput) error {
 			SchemaVersion:   SchemaVersion,
 			CreatedAt:       time.Now(),
 			BaseDirs:        expandedDirs,
+			ExcludePaths:    expandedExcludes,
 			PatternsHash:    computePatternsHash(input.Patterns),
 			MaxDepth:        input.MaxDepth,
 			FollowSymlinks:  input.FollowSymlinks,
@@ -265,6 +280,7 @@ func (s *Store) Save(ctx context.Context, input SaveInput) error {
 
 	cacheFile := s.cacheFilePath(cacheKeyInput{
 		baseDirs:       input.BaseDirs,
+		excludePaths:   input.ExcludePaths,
 		patterns:       input.Patterns,
 		maxDepth:       input.MaxDepth,
 		followSymlinks: input.FollowSymlinks,
@@ -324,6 +340,7 @@ func (s *Store) cacheFilePath(input cacheKeyInput) string {
 // cacheKeyInput holds parameters for computing the cache key
 type cacheKeyInput struct {
 	baseDirs       []string
+	excludePaths   []string
 	patterns       []fileindex.Pattern
 	maxDepth       int
 	followSymlinks bool
@@ -343,6 +360,13 @@ func computeCacheKey(input cacheKeyInput) string {
 		fmt.Fprintf(h, "dir:%s\n", dir)
 	}
 
+	// Expand and sort exclude paths for consistent hashing
+	expandedExcludes := ExpandBaseDirs(input.excludePaths)
+	sort.Strings(expandedExcludes)
+	for _, p := range expandedExcludes {
+		fmt.Fprintf(h, "exclude:%s\n", p)
+	}
+
 	// Include patterns hash
 	fmt.Fprintf(h, "patterns:%s\n", computePatternsHash(input.patterns))
 
@@ -351,6 +375,14 @@ func computeCacheKey(input cacheKeyInput) string {
 	fmt.Fprintf(h, "followSymlinks:%t\n", input.followSymlinks)
 
 	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// sortedCopy returns a sorted copy of a string slice
+func sortedCopy(s []string) []string {
+	c := make([]string, len(s))
+	copy(c, s)
+	sort.Strings(c)
+	return c
 }
 
 // computePatternsHash computes a hash of the patterns configuration

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -164,6 +164,7 @@ func (c *Collector) buildFileIndex(ctx context.Context) (*fileindex.FileIndex, e
 
 	input := fileindex.BuildIndexInput{
 		BaseDirs:         baseDirs,
+		ExcludePaths:     c.config.FileIndex.ExcludePaths,
 		Patterns:         patterns,
 		MaxDepth:         c.config.FileIndex.MaxDepth,
 		FollowSymlinks:   c.config.FileIndex.FollowSymlinks,
@@ -207,6 +208,7 @@ func (c *Collector) loadFromCache(ctx context.Context, baseDirs []string, patter
 
 	index, err := c.cacheStore.Load(ctx, cache.LoadInput{
 		BaseDirs:       baseDirs,
+		ExcludePaths:   c.config.FileIndex.ExcludePaths,
 		Patterns:       patterns,
 		MaxDepth:       c.config.FileIndex.MaxDepth,
 		FollowSymlinks: c.config.FileIndex.FollowSymlinks,
@@ -228,6 +230,7 @@ func (c *Collector) saveToCache(ctx context.Context, baseDirs []string, patterns
 
 	if err := c.cacheStore.Save(ctx, cache.SaveInput{
 		BaseDirs:       baseDirs,
+		ExcludePaths:   c.config.FileIndex.ExcludePaths,
 		Patterns:       patterns,
 		MaxDepth:       c.config.FileIndex.MaxDepth,
 		FollowSymlinks: c.config.FileIndex.FollowSymlinks,

--- a/pkg/fileindex/fileindex.go
+++ b/pkg/fileindex/fileindex.go
@@ -100,6 +100,7 @@ type Pattern struct {
 // BuildIndexInput holds the input parameters for building a file index
 type BuildIndexInput struct {
 	BaseDirs         []string              // Base directories to search (e.g., ["$HOME"])
+	ExcludePaths     []string              // Paths to skip entirely (e.g., ["~/repos", "~/.cache"])
 	Patterns         []Pattern             // Patterns to match
 	MaxDepth         int                   // Maximum recursion depth (0 = unlimited)
 	FollowSymlinks   bool                  // Whether to follow symbolic links
@@ -116,6 +117,18 @@ func BuildIndex(ctx context.Context, input BuildIndexInput) (*FileIndex, error) 
 		expanded := expandHomeDir(dir)
 		expandedDirs = append(expandedDirs, expanded)
 	}
+
+	// Expand and normalize exclude paths so that inputs like "~/repos/" or
+	// Windows forward-slash paths match correctly inside isExcludedPath.
+	expandedExcludes := make([]string, 0, len(input.ExcludePaths))
+	for _, p := range input.ExcludePaths {
+		expanded := expandHomeDir(p)
+		if expanded != "" {
+			expanded = filepath.Clean(filepath.FromSlash(expanded))
+		}
+		expandedExcludes = append(expandedExcludes, expanded)
+	}
+	input.ExcludePaths = expandedExcludes
 
 	log.Ctx(ctx).Info().
 		Strs("base_dirs", expandedDirs).
@@ -228,6 +241,14 @@ func walkDirectory(
 		return
 	}
 
+	// Check if current directory is excluded
+	if isExcludedPath(currentDir, input.ExcludePaths) {
+		log.Ctx(ctx).Debug().
+			Str("dir", currentDir).
+			Msg("Skipping excluded directory")
+		return
+	}
+
 	// Check if context is cancelled
 	select {
 	case <-ctx.Done():
@@ -324,6 +345,24 @@ func walkDirectory(
 		matchFile(ctx, baseDir, fullPath, patterns, index)
 		filesProcessed.Add(1)
 	}
+}
+
+// isExcludedPath reports whether path should be skipped during file index building.
+// A path is excluded if it equals any entry in excludePaths, or is a child of one.
+// excludePaths must already be expanded and normalized (no ~ or $HOME variables).
+func isExcludedPath(path string, excludePaths []string) bool {
+	cleanedPath := filepath.Clean(path)
+	for _, excluded := range excludePaths {
+		trimmed := strings.TrimSpace(excluded)
+		if trimmed == "" {
+			continue
+		}
+		cleanedExcluded := filepath.Clean(trimmed)
+		if cleanedPath == cleanedExcluded || strings.HasPrefix(cleanedPath, cleanedExcluded+string(os.PathSeparator)) {
+			return true
+		}
+	}
+	return false
 }
 
 // expandHomeDir expands $HOME, %USERPROFILE%, and ~ to the user's home directory.

--- a/pkg/fileindex/fileindex.go
+++ b/pkg/fileindex/fileindex.go
@@ -118,15 +118,22 @@ func BuildIndex(ctx context.Context, input BuildIndexInput) (*FileIndex, error) 
 		expandedDirs = append(expandedDirs, expanded)
 	}
 
-	// Expand and normalize exclude paths so that inputs like "~/repos/" or
-	// Windows forward-slash paths match correctly inside isExcludedPath.
+	// Expand and normalize exclude paths. TrimSpace before expansion so that
+	// entries like " ~/repos " correctly expand the ~ prefix. Empty entries
+	// after trimming are dropped so they cannot accidentally match all paths.
 	expandedExcludes := make([]string, 0, len(input.ExcludePaths))
 	for _, p := range input.ExcludePaths {
-		expanded := expandHomeDir(p)
+		trimmed := strings.TrimSpace(p)
+		if trimmed == "" {
+			continue
+		}
+		expanded := expandHomeDir(trimmed)
 		if expanded != "" {
 			expanded = filepath.Clean(filepath.FromSlash(expanded))
 		}
-		expandedExcludes = append(expandedExcludes, expanded)
+		if expanded != "" {
+			expandedExcludes = append(expandedExcludes, expanded)
+		}
 	}
 	input.ExcludePaths = expandedExcludes
 
@@ -348,8 +355,10 @@ func walkDirectory(
 }
 
 // isExcludedPath reports whether path should be skipped during file index building.
-// A path is excluded if it equals any entry in excludePaths, or is a child of one.
+// A path is excluded if it equals any entry in excludePaths, or is a descendant of one.
 // excludePaths must already be expanded and normalized (no ~ or $HOME variables).
+// filepath.Rel is used for the containment check so that root or volume-root excludes
+// (e.g. "/" on Unix) are handled correctly.
 func isExcludedPath(path string, excludePaths []string) bool {
 	cleanedPath := filepath.Clean(path)
 	for _, excluded := range excludePaths {
@@ -358,7 +367,15 @@ func isExcludedPath(path string, excludePaths []string) bool {
 			continue
 		}
 		cleanedExcluded := filepath.Clean(trimmed)
-		if cleanedPath == cleanedExcluded || strings.HasPrefix(cleanedPath, cleanedExcluded+string(os.PathSeparator)) {
+		if cleanedPath == cleanedExcluded {
+			return true
+		}
+		rel, err := filepath.Rel(cleanedExcluded, cleanedPath)
+		if err != nil {
+			continue
+		}
+		// rel starts with ".." only when cleanedPath is outside cleanedExcluded
+		if rel != ".." && !strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
 			return true
 		}
 	}

--- a/pkg/fileindex/fileindex_test.go
+++ b/pkg/fileindex/fileindex_test.go
@@ -654,3 +654,58 @@ func TestBuildIndex_Concurrent_MultipleBaseDirs(t *testing.T) {
 	assert.Contains(t, gitconfigs, filepath.Join(tmpDir2, ".gitconfig"))
 	assert.Contains(t, gitconfigs, filepath.Join(tmpDir3, ".gitconfig"))
 }
+
+func TestBuildIndex_WithExcludePaths(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Create a structure with files in both an included and an excluded directory
+	includedDir := filepath.Join(tmpDir, "home")
+	excludedDir := filepath.Join(tmpDir, "repos")
+
+	for _, dir := range []string{includedDir, filepath.Join(includedDir, ".ssh"), excludedDir, filepath.Join(excludedDir, "proj", ".ssh")} {
+		require.NoError(t, os.MkdirAll(dir, 0755))
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(includedDir, ".gitconfig"), []byte("included"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(includedDir, ".ssh", "config"), []byte("included"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(excludedDir, ".gitconfig"), []byte("excluded"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(excludedDir, "proj", ".ssh", "config"), []byte("excluded"), 0644))
+
+	patterns := []Pattern{
+		{
+			Name:     "gitconfig",
+			Patterns: []string{".gitconfig"},
+			Type:     PatternTypeExact,
+		},
+		{
+			Name:     "ssh_config",
+			Patterns: []string{".ssh/config"},
+			Type:     PatternTypeGlob,
+		},
+	}
+
+	input := BuildIndexInput{
+		BaseDirs:       []string{tmpDir},
+		ExcludePaths:   []string{excludedDir},
+		Patterns:       patterns,
+		MaxDepth:       0,
+		FollowSymlinks: false,
+	}
+
+	ctx := context.Background()
+	index, err := BuildIndex(ctx, input)
+	require.NoError(t, err)
+
+	// Only files outside the excluded directory should be found
+	gitconfigs := index.Get("gitconfig")
+	assert.Len(t, gitconfigs, 1)
+	assert.Contains(t, gitconfigs, filepath.Join(includedDir, ".gitconfig"))
+	assert.NotContains(t, gitconfigs, filepath.Join(excludedDir, ".gitconfig"))
+
+	sshConfigs := index.Get("ssh_config")
+	assert.Len(t, sshConfigs, 1)
+	assert.Contains(t, sshConfigs, filepath.Join(includedDir, ".ssh", "config"))
+	assert.NotContains(t, sshConfigs, filepath.Join(excludedDir, "proj", ".ssh", "config"))
+}

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -55,6 +55,7 @@ type FileIndexConfig struct {
 	MaxDepth       int             `yaml:"max_depth" mapstructure:"max_depth"`
 	FollowSymlinks bool            `yaml:"follow_symlinks" mapstructure:"follow_symlinks"`
 	BaseDirs       []string        `yaml:"base_dirs" mapstructure:"base_dirs"`
+	ExcludePaths   []string        `yaml:"exclude_paths" mapstructure:"exclude_paths"`
 	Patterns       []PatternConfig `yaml:"patterns" mapstructure:"patterns"`
 	Cache          CacheConfig     `yaml:"cache" mapstructure:"cache"`
 }


### PR DESCRIPTION
## Summary

Adds `file_index.exclude_paths` to `bagel.yaml` so users can opt entire directory trees out of the file index walk:

```yaml
file_index:
  exclude_paths:
    - ~/projects
    - ~/.cache
```

This is useful on machines with large project trees (e.g. many `node_modules` copies or git worktrees) where the default unlimited walk produces millions of files and makes the index build slow.

## Changes

- `pkg/models/config.go` — add `ExcludePaths []string` to `FileIndexConfig`
- `pkg/fileindex/fileindex.go` — expand/normalize exclude paths at build time; `walkDirectory()` returns early when `currentDir` matches an excluded path (exact match or child prefix); empty/whitespace entries are ignored; paths normalized with `filepath.Clean`/`filepath.FromSlash`
- `pkg/collector/collector.go` — pass `ExcludePaths` from config into `BuildIndexInput`, `cache.LoadInput`, and `cache.SaveInput`
- `pkg/cache/cache.go` — include `ExcludePaths` in cache key and `Metadata` so changing the list invalidates stale cache entries; `SchemaVersion` bumped to 4

## Tests

`TestBuildIndex_WithExcludePaths` — verifies that files inside an excluded directory are not indexed while files in a sibling directory still are.