### PR TITLE
Add Check for gh CLI Bad Cleanup on Log Out on MacOS

### DIFF
--- a/cmd/bagel/scan.go
+++ b/cmd/bagel/scan.go
@@ -163,7 +163,7 @@ func initializeProbes(cfg *models.Config) []probe.Probe {
 
 	// GitHub CLI probe
 	if cfg.Probes.GH.Enabled {
-		probes = append(probes, probe.NewGHProbe(cfg.Probes.GH))
+		probes = append(probes, probe.NewGHProbe(cfg.Probes.GH, registry))
 	}
 
 	// AI CLI probe

--- a/pkg/probe/gh.go
+++ b/pkg/probe/gh.go
@@ -6,23 +6,33 @@ package probe
 import (
 	"context"
 	"os/exec"
+	"runtime"
+	"strings"
 
+	"github.com/boostsecurityio/bagel/pkg/detector"
 	"github.com/boostsecurityio/bagel/pkg/models"
 	"github.com/rs/zerolog/log"
 )
 
 // GHProbe checks for GitHub CLI authentication
 type GHProbe struct {
-	enabled bool
-	config  models.ProbeSettings
+	enabled          bool
+	config           models.ProbeSettings
+	detectorRegistry *detector.Registry
 }
 
 // NewGHProbe creates a new GitHub CLI probe
-func NewGHProbe(config models.ProbeSettings) *GHProbe {
+func NewGHProbe(config models.ProbeSettings, registry *detector.Registry) *GHProbe {
 	return &GHProbe{
-		enabled: config.Enabled,
-		config:  config,
+		enabled:          config.Enabled,
+		config:           config,
+		detectorRegistry: registry,
 	}
+}
+
+// SetFingerprintSalt sets the fingerprint salt on the detector registry (implements FingerprintSaltAware)
+func (p *GHProbe) SetFingerprintSalt(salt string) {
+	p.detectorRegistry.SetFingerprintSalt(salt)
 }
 
 // Name returns the probe name
@@ -58,32 +68,97 @@ func (p *GHProbe) Execute(ctx context.Context) ([]models.Finding, error) {
 
 	// Run the command - we only care about the exit code
 	// The token value is intentionally discarded and never stored
-	err = cmd.Run()
-	if err != nil {
-		// Command failed - either not authenticated or some other error
-		// This is expected when gh is not authenticated
-		log.Ctx(ctx).Debug().
-			Err(err).
-			Msg("GitHub CLI not authenticated or command failed")
-		return findings, nil
+	ghAuthenticated := cmd.Run() == nil
+
+	if ghAuthenticated {
+		findings = append(findings, models.Finding{
+			ID:          "gh-auth-token-present",
+			Type:        models.FindingTypeSecret,
+			Fingerprint: models.FingerprintFromFields("gh-auth-token-present", ghPath),
+			Probe:       p.Name(),
+			Severity:    "medium",
+			Title:       "GitHub CLI Authentication Detected",
+			Description: "An active GitHub CLI session was found. " +
+				"If this machine is compromised, the session token can be used to access your GitHub account, repositories, and organization resources.",
+			Message: "GitHub CLI authenticated at " + ghPath,
+			Path:    ghPath,
+			Metadata: map[string]interface{}{
+				"gh_path": ghPath,
+			},
+		})
+	} else {
+		log.Ctx(ctx).Debug().Msg("GitHub CLI not authenticated")
 	}
 
-	// If we get here, gh auth token succeeded - there's an active session
-	findings = append(findings, models.Finding{
-		ID:          "gh-auth-token-present",
-		Type:        models.FindingTypeSecret,
-		Fingerprint: models.FingerprintFromFields("gh-auth-token-present", ghPath),
-		Probe:       p.Name(),
-		Severity:    "medium",
-		Title:       "GitHub CLI Authentication Detected",
-		Description: "An active GitHub CLI session allows attackers to access your GitHub account, repositories, and organization resources if this machine is compromised. " +
-			"Consider using 'gh auth logout' when not actively using the CLI.",
-		Message: "GitHub CLI authenticated at " + ghPath,
-		Path:    ghPath,
-		Metadata: map[string]interface{}{
-			"gh_path": ghPath,
-		},
-	})
+	// On macOS, gh auth logout does not remove the OAuth token from the
+	// macOS Keychain (https://github.com/cli/cli/issues/13111).
+	// Check for leftover credentials regardless of gh auth status.
+	if runtime.GOOS == "darwin" {
+		findings = append(findings, p.checkKeychainLeftover(ctx, ghAuthenticated)...)
+	}
 
 	return findings, nil
+}
+
+// checkKeychainLeftover queries git credential-osxkeychain for a leftover
+// github.com OAuth token that gh auth logout fails to remove.
+func (p *GHProbe) checkKeychainLeftover(ctx context.Context, ghAuthenticated bool) []models.Finding {
+	// If gh is authenticated, the keychain credential is expected -- skip.
+	if ghAuthenticated {
+		return nil
+	}
+
+	// Only relevant when git credential-osxkeychain is available
+	credHelper := exec.CommandContext(ctx, "git", "credential-osxkeychain", "get")
+	credHelper.Stdin = strings.NewReader("protocol=https\nhost=github.com\n\n")
+
+	output, err := credHelper.Output()
+	if err != nil {
+		log.Ctx(ctx).Debug().
+			Err(err).
+			Msg("No GitHub credential in macOS Keychain")
+		return nil
+	}
+
+	// Extract the password value
+	var password string
+	for _, line := range strings.Split(string(output), "\n") {
+		if strings.HasPrefix(line, "password=") {
+			password = strings.TrimPrefix(line, "password=")
+			break
+		}
+	}
+
+	if password == "" {
+		return nil
+	}
+
+	// Run the password through the detector registry to confirm it's a known token type
+	detCtx := models.NewDetectionContext(models.NewDetectionContextInput{
+		Source:    "osxkeychain:github.com",
+		ProbeName: p.Name(),
+	})
+	findings := p.detectorRegistry.DetectAll(password, detCtx)
+
+	if len(findings) == 0 {
+		return nil
+	}
+
+	// Annotate each finding with keychain-specific context
+	for i := range findings {
+		findings[i].ID = "gh-keychain-leftover-" + findings[i].ID
+		findings[i].Title = findings[i].Title + " (left in macOS Keychain after logout)"
+		findings[i].Description = "gh auth logout does not remove the OAuth token from the macOS Keychain " +
+			"(https://github.com/cli/cli/issues/13111). The token remains accessible via " +
+			"git credential-osxkeychain and can be used to authenticate as you. " +
+			"Remove it manually: printf 'protocol=https\\nhost=github.com\\n\\n' | git credential-osxkeychain erase"
+		findings[i].Path = "osxkeychain:github.com"
+		if findings[i].Metadata == nil {
+			findings[i].Metadata = make(map[string]interface{})
+		}
+		findings[i].Metadata["credential_helper"] = "osxkeychain"
+		findings[i].Metadata["host"] = "github.com"
+	}
+
+	return findings
 }

--- a/pkg/probe/gh_test.go
+++ b/pkg/probe/gh_test.go
@@ -6,15 +6,17 @@ package probe
 import (
 	"context"
 	"os/exec"
+	"runtime"
 	"testing"
 
+	"github.com/boostsecurityio/bagel/pkg/detector"
 	"github.com/boostsecurityio/bagel/pkg/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGHProbe_Name(t *testing.T) {
-	probe := NewGHProbe(models.ProbeSettings{Enabled: true})
+	probe := NewGHProbe(models.ProbeSettings{Enabled: true}, detector.NewRegistry())
 	assert.Equal(t, "gh", probe.Name())
 }
 
@@ -38,7 +40,7 @@ func TestGHProbe_IsEnabled(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			probe := NewGHProbe(models.ProbeSettings{Enabled: tt.enabled})
+			probe := NewGHProbe(models.ProbeSettings{Enabled: tt.enabled}, detector.NewRegistry())
 			assert.Equal(t, tt.want, probe.IsEnabled())
 		})
 	}
@@ -49,7 +51,7 @@ func TestGHProbe_Execute_GHNotInstalled(t *testing.T) {
 	// t.Setenv automatically restores the original value after the test
 	t.Setenv("PATH", "/nonexistent")
 
-	probe := NewGHProbe(models.ProbeSettings{Enabled: true})
+	probe := NewGHProbe(models.ProbeSettings{Enabled: true}, detector.NewRegistry())
 	findings, err := probe.Execute(context.Background())
 
 	require.NoError(t, err)
@@ -63,7 +65,7 @@ func TestGHProbe_Execute_Integration(t *testing.T) {
 		t.Skip("gh CLI not installed, skipping integration test")
 	}
 
-	probe := NewGHProbe(models.ProbeSettings{Enabled: true})
+	probe := NewGHProbe(models.ProbeSettings{Enabled: true}, detector.NewRegistry())
 	findings, err := probe.Execute(context.Background())
 
 	require.NoError(t, err)
@@ -92,10 +94,40 @@ func TestGHProbe_Execute_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	probe := NewGHProbe(models.ProbeSettings{Enabled: true})
+	probe := NewGHProbe(models.ProbeSettings{Enabled: true}, detector.NewRegistry())
 	findings, err := probe.Execute(ctx)
 
 	// With a cancelled context, the command should fail and return no findings
 	require.NoError(t, err)
 	assert.Empty(t, findings, "Should return no findings when context is cancelled")
+}
+
+func TestGHProbe_CheckKeychainLeftover_NoCredential(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS-only test")
+	}
+
+	registry := detector.NewRegistry()
+	registry.Register(detector.NewGitHubPATDetector())
+
+	probe := NewGHProbe(models.ProbeSettings{Enabled: true}, registry)
+	findings := probe.checkKeychainLeftover(context.Background(), false)
+
+	// We can't assert the exact result since it depends on keychain state,
+	// but the method should not panic or return an error
+	_ = findings
+}
+
+func TestGHProbe_CheckKeychainLeftover_SkipsWhenAuthenticated(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("macOS-only test")
+	}
+
+	registry := detector.NewRegistry()
+	registry.Register(detector.NewGitHubPATDetector())
+
+	probe := NewGHProbe(models.ProbeSettings{Enabled: true}, registry)
+	// When gh is authenticated, leftover keychain creds are expected -- no finding
+	findings := probe.checkKeychainLeftover(context.Background(), true)
+	assert.Empty(t, findings, "Should not report keychain credential when gh is authenticated")
 }


### PR DESCRIPTION
add check for leftover github token after gh auth logout on macos. Fixes #36 