### PR TITLE
Changes finding title to be one for one with finding ID.

### DIFF
--- a/CLA_SIGNATURES.md
+++ b/CLA_SIGNATURES.md
@@ -5,3 +5,4 @@ julien-boost - Julien Champoux
 GuillaumeRoss - Guillaume Ross
 c0tton-fluff - Michal Ambrozkiewicz
 tveronezi - Thiago Veronezi
+stlef14 - Stephan Lefrancois

--- a/pkg/detector/ai_service.go
+++ b/pkg/detector/ai_service.go
@@ -46,28 +46,33 @@ func NewAIServiceDetector() *AIServiceDetector {
 				regex:       regexp.MustCompile(`\b(sk-(?:proj|svcacct|admin)-(?:[A-Za-z0-9_-]{74}|[A-Za-z0-9_-]{58})T3BlbkFJ(?:[A-Za-z0-9_-]{74}|[A-Za-z0-9_-]{58})\b|sk-[a-zA-Z0-9]{20}T3BlbkFJ[a-zA-Z0-9]{20})(?:[\x60'"\s;]|\\[nr]|$)`),
 				tokenType:   "openai-api-key",
 				description: "OpenAI API Key",
+				title:       "OpenAI API Key Detected",
 			},
 			"anthropic": {
 				// Remove backslash before hyphen in character class
 				regex:       regexp.MustCompile(`\b(sk-ant-api03-[a-zA-Z0-9_\-]{93}AA)(?:[\x60'"\s;]|\\[nr]|$)`),
 				tokenType:   "anthropic-api-key",
 				description: "Anthropic API Key",
+				title:       "Anthropic API Key Detected",
 			},
 			"anthropic_admin": {
 				// Remove backslash before hyphen in character class
 				regex:       regexp.MustCompile(`\b(sk-ant-admin01-[a-zA-Z0-9_\-]{93}AA)(?:[\x60'"\s;]|\\[nr]|$)`),
 				tokenType:   "anthropic-admin-api-key",
 				description: "Anthropic Admin API Key",
+				title:       "Anthropic Admin API Key Detected",
 			},
 			"huggingface": {
 				regex:       regexp.MustCompile(`\b(hf_(?i:[a-z]{34}))(?:[\x60'"\s;]|\\[nr]|$)`),
 				tokenType:   "huggingface-access-token",
 				description: "Hugging Face Access Token",
+				title:       "Hugging Face Access Token Detected",
 			},
 			"huggingface_org": {
 				regex:       regexp.MustCompile(`\b(api_org_(?i:[a-z]{34}))(?:[\x60'"\s;]|\\[nr]|$)`),
 				tokenType:   "huggingface-org-token",
 				description: "Hugging Face Organization API Token",
+				title:       "Hugging Face API Token Detected",
 			},
 		},
 	}
@@ -108,7 +113,7 @@ func (d *AIServiceDetector) createFinding(token string, pattern *tokenPattern, c
 		Type:        models.FindingTypeSecret,
 		Fingerprint: models.SaltedFingerprint(token, ctx.FingerprintSalt),
 		Severity:    "critical",
-		Title:       "AI Service API Key Detected",
+		Title:       pattern.title,
 		Description: "AI service credentials provide access to paid services and may incur costs or expose sensitive data. " +
 			"Revoke this key immediately and rotate with a new one stored securely.",
 		Message: fmt.Sprintf("A %s was detected in %s.", pattern.description, ctx.FormatSource()),

--- a/pkg/detector/cloud_credentials.go
+++ b/pkg/detector/cloud_credentials.go
@@ -75,6 +75,7 @@ func NewCloudCredentialsDetector() *CloudCredentialsDetector {
 				regex:       regexp.MustCompile(`(?:^|[^A-Za-z0-9+/])([A-Za-z0-9+/]{88}==)(?:[^A-Za-z0-9+/=]|$)`),
 				tokenType:   "azure-storage-key",
 				description: "Azure Storage Account Key",
+				title:       "Azure Storage Account Key Detected",
 			},
 
 			// AWS Credentials
@@ -84,6 +85,7 @@ func NewCloudCredentialsDetector() *CloudCredentialsDetector {
 				regex:       regexp.MustCompile(`\b((?:A3T[A-Z0-9]|AKIA|ASIA|ABIA|ACCA)[A-Z2-7]{16})\b`),
 				tokenType:   "aws-access-key-id",
 				description: "AWS Access Key ID",
+				title:       "AWS Access Key ID Detected",
 			},
 
 			// Google Cloud Credentials
@@ -92,6 +94,7 @@ func NewCloudCredentialsDetector() *CloudCredentialsDetector {
 				regex:       regexp.MustCompile(`\b(AIza[A-Za-z0-9_-]{35})\b`),
 				tokenType:   "gcp-api-key",
 				description: "Google Cloud API Key",
+				title:       "Google Cloud API Key Detected",
 			},
 
 			// AWS Session Token (labeled)
@@ -99,6 +102,7 @@ func NewCloudCredentialsDetector() *CloudCredentialsDetector {
 				regex:       regexp.MustCompile(`(?:aws_session_token|AWS_SESSION_TOKEN|SessionToken)["\s:=]+([A-Za-z0-9+/=]{100,})`),
 				tokenType:   "aws-session-token",
 				description: "AWS Session Token",
+				title:       "AWS Session Token Detected",
 			},
 
 			// AWS STS Session Token (label-free, base64 prefix)
@@ -106,6 +110,7 @@ func NewCloudCredentialsDetector() *CloudCredentialsDetector {
 				regex:       regexp.MustCompile(`\b(IQoJb3JpZ2lu[A-Za-z0-9+/=]{100,})\b`),
 				tokenType:   "aws-sts-session-token",
 				description: "AWS STS Session Token",
+				title:       "AWS STS Session Token Detected",
 			},
 
 			// AWS Secret Access Key (labeled)
@@ -113,6 +118,7 @@ func NewCloudCredentialsDetector() *CloudCredentialsDetector {
 				regex:       regexp.MustCompile(`(?:aws_secret_access_key|secret_access_key|SecretAccessKey)["\s:=]+([A-Za-z0-9+/]{40})`),
 				tokenType:   "aws-secret-access-key",
 				description: "AWS Secret Access Key",
+				title:       "AWS Secret Access Key Detected",
 			},
 		},
 	}
@@ -163,7 +169,7 @@ func (d *CloudCredentialsDetector) createFinding(credential string, pattern *tok
 		Type:        models.FindingTypeSecret,
 		Fingerprint: models.SaltedFingerprint(credential, ctx.FingerprintSalt),
 		Severity:    "critical",
-		Title:       "Cloud Credential Detected",
+		Title:       pattern.title,
 		Description: "Cloud credentials provide access to infrastructure and services. " +
 			"Exposed credentials risk unauthorized access to cloud resources.",
 		Message: fmt.Sprintf("A %s was detected in %s.", pattern.description, ctx.FormatSource()),

--- a/pkg/detector/github_pat.go
+++ b/pkg/detector/github_pat.go
@@ -20,6 +20,7 @@ type tokenPattern struct {
 	regex       *regexp.Regexp
 	tokenType   string
 	description string
+	title       string
 }
 
 // NewGitHubPATDetector creates a new GitHub token detector
@@ -30,31 +31,37 @@ func NewGitHubPATDetector() *GitHubTokenDetector {
 				regex:       regexp.MustCompile(`ghp_[A-Za-z0-9]{36}`),
 				tokenType:   "classic-pat",
 				description: "Classic Personal Access Token",
+				title:       "GitHub Classic Personal Access Token Detected",
 			},
 			"github_pat": {
 				regex:       regexp.MustCompile(`github_pat_\w{82}`),
 				tokenType:   "fine-grained-pat",
 				description: "Fine-grained Personal Access Token",
+				title:       "GitHub Fine-grained Personal Access Token Detected",
 			},
 			"gho": {
 				regex:       regexp.MustCompile(`gho_[A-Za-z0-9]{36}`),
 				tokenType:   "oauth-token",
 				description: "OAuth Access Token",
+				title:       "GitHub OAuth Access Token Detected",
 			},
 			"ghu": {
 				regex:       regexp.MustCompile(`ghu_[A-Za-z0-9]{36}`),
 				tokenType:   "app-user-token",
 				description: "GitHub App User-to-Server Token",
+				title:       "GitHub App User-to-Server Token Detected",
 			},
 			"ghs": {
 				regex:       regexp.MustCompile(`ghs_[A-Za-z0-9]{36}`),
 				tokenType:   "app-server-token",
 				description: "GitHub App Server-to-Server Token",
+				title:       "GitHub App Server-to-Server Token Detected",
 			},
 			"ghr": {
 				regex:       regexp.MustCompile(`ghr_[A-Za-z0-9]{36}`),
 				tokenType:   "refresh-token",
 				description: "GitHub Refresh Token",
+				title:       "GitHub Refresh Token Detected",
 			},
 		},
 		redactPatterns: []RedactPattern{
@@ -124,7 +131,7 @@ func (d *GitHubTokenDetector) createFinding(token string, pattern *tokenPattern,
 		Type:        models.FindingTypeSecret,
 		Fingerprint: models.SaltedFingerprint(token, ctx.FingerprintSalt),
 		Severity:    "critical",
-		Title:       "GitHub Token Detected",
+		Title:       pattern.title,
 		Description: "GitHub tokens provide access to your account and repositories.",
 		Message:     fmt.Sprintf("A %s was detected in %s.", pattern.description, ctx.FormatSource()),
 		Path:        ctx.Source,

--- a/pkg/detector/http_auth.go
+++ b/pkg/detector/http_auth.go
@@ -63,12 +63,14 @@ func NewHTTPAuthDetector() *HTTPAuthDetector {
 				regex:       regexp.MustCompile(`(?i)\bAuthorization:\s*(?:Bearer|(?:Api-)?Token)\s+([\w=~@.+/-]{16,})\b`),
 				tokenType:   "bearer-token",
 				description: "Bearer Token in Authorization Header",
+				title:       "HTTP Bearer Token Detected",
 			},
 			"basic-auth": {
 				// Matches: Authorization: Basic <base64>
 				regex:       regexp.MustCompile(`(?i)\bAuthorization:\s*Basic\s+([a-zA-Z0-9+/]{16,}={0,2})\b`),
 				tokenType:   "basic-auth",
 				description: "Basic Authentication in Authorization Header",
+				title:       "HTTP Basic Authentication Detected",
 			},
 			"api-key-header": {
 				// Matches various API key header formats:
@@ -76,12 +78,14 @@ func NewHTTPAuthDetector() *HTTPAuthDetector {
 				regex:       regexp.MustCompile(`(?i)\b(?:X-)?(?:API|Api)-?(?:Key|Token):\s*([\w=~@.+/-]{16,})\b`),
 				tokenType:   "api-key-header",
 				description: "API Key in Header",
+				title:       "HTTP API Key Detected",
 			},
 			"basic-auth-url": {
 				// Matches: username:password@ in URLs (http://user:pass@host)
 				regex:       regexp.MustCompile(`(?i)\b(?:https?|ftp)://([a-zA-Z0-9_.-]{3,}):([^@\s]{3,})@`),
 				tokenType:   "basic-auth-url",
 				description: "Basic Authentication in URL",
+				title:       "HTTP Basic Authentication URL Detected",
 			},
 		},
 	}
@@ -123,7 +127,7 @@ func (d *HTTPAuthDetector) createFinding(credential string, pattern *tokenPatter
 		Type:        models.FindingTypeSecret,
 		Fingerprint: models.SaltedFingerprint(credential, ctx.FingerprintSalt),
 		Severity:    "critical",
-		Title:       "HTTP Authentication Credential Detected",
+		Title:       pattern.title,
 		Description: "HTTP authentication credentials in plain text may be exposed in logs, shell history, or configuration files. " +
 			"Use secure credential storage or secret management systems instead.",
 		Message: fmt.Sprintf("A %s was detected in %s.", pattern.description, ctx.FormatSource()),

--- a/pkg/detector/jwt.go
+++ b/pkg/detector/jwt.go
@@ -37,6 +37,7 @@ func NewJWTDetector() *JWTDetector {
 				regex:       regexp.MustCompile(`\b(ey[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+\.[A-Za-z0-9-_]+)\b($|[^.])`),
 				tokenType:   "jwt-token",
 				description: "JWT Token",
+				title:       "JWT Token Detected",
 			},
 			"jwe-token": {
 				// Matches: <base64_header>.<base64_enc_key>.<base64_iv>.<base64_ct>.<base64_tag>
@@ -45,6 +46,7 @@ func NewJWTDetector() *JWTDetector {
 				regex:       regexp.MustCompile(`\b(ey[A-Za-z0-9-_]+(?:\.[A-Za-z0-9-_]+){4})\b`),
 				tokenType:   "jwe-token",
 				description: "JWE Token",
+				title:       "JWE Token Detected",
 			},
 		},
 	}
@@ -86,7 +88,7 @@ func (d *JWTDetector) createFinding(credential string, pattern *tokenPattern, ct
 		Type:        models.FindingTypeSecret,
 		Fingerprint: models.SaltedFingerprint(credential, ctx.FingerprintSalt),
 		Severity:    "critical",
-		Title:       "JWT Token Detected",
+		Title:       pattern.title,
 		Description: "JWT tokens in plain text can be exposed in logs, shell history, or configuration files. " +
 			"Use secure credential storage or secret management systems instead.",
 		Message: fmt.Sprintf("A %s was detected in %s.", pattern.description, ctx.FormatSource()),

--- a/pkg/detector/ssh_private_key.go
+++ b/pkg/detector/ssh_private_key.go
@@ -141,6 +141,28 @@ func (d *SSHPrivateKeyDetector) Redact(content string) (string, map[string]int) 
 	return ApplyRedactPatterns(content, d.redactPatterns)
 }
 
+const sshPrivateKeyDetectedSuffix = "Private Key Detected"
+
+// sshPrivateKeyTitle returns a finding title specific to the SSH private key type.
+func sshPrivateKeyTitle(keyType string) string {
+	var prefix string
+	switch strings.ToUpper(keyType) {
+	case "RSA":
+		prefix = "RSA SSH "
+	case "DSA":
+		prefix = "DSA SSH "
+	case "EC":
+		prefix = "EC SSH "
+	case "OPENSSH":
+		prefix = "OpenSSH "
+	case "PKCS8":
+		prefix = "PKCS8 SSH "
+	default:
+		prefix = "SSH "
+	}
+	return prefix + sshPrivateKeyDetectedSuffix
+}
+
 // createFinding creates a finding for a detected SSH private key
 func (d *SSHPrivateKeyDetector) createFinding(keyContent, keyType string, isEncrypted bool, ctx *models.DetectionContext) models.Finding {
 	var severity string
@@ -162,7 +184,7 @@ func (d *SSHPrivateKeyDetector) createFinding(keyContent, keyType string, isEncr
 		Type:        models.FindingTypeSecret,
 		Fingerprint: models.SaltedFingerprint(keyContent, ctx.FingerprintSalt),
 		Severity:    severity,
-		Title:       "SSH Private Key Detected",
+		Title:       sshPrivateKeyTitle(keyType),
 		Description: description,
 		Message:     fmt.Sprintf("A %s SSH private key was detected in %s.", keyType, ctx.FormatSource()),
 		Path:        ctx.Source,

--- a/pkg/detector/vault_token.go
+++ b/pkg/detector/vault_token.go
@@ -66,8 +66,10 @@ func (d *VaultTokenDetector) Detect(
 			seen[match] = true
 
 			tokenType := "vault-service-token"
+			title := "HashiCorp Vault Service Token Detected"
 			if match[0] == 's' {
 				tokenType = "vault-legacy-token"
+				title = "HashiCorp Vault Legacy Token Detected"
 			}
 
 			findings = append(findings, models.Finding{
@@ -75,7 +77,7 @@ func (d *VaultTokenDetector) Detect(
 				Type:        models.FindingTypeSecret,
 				Fingerprint: models.SaltedFingerprint(match, ctx.FingerprintSalt),
 				Severity:    "critical",
-				Title:       "HashiCorp Vault Token Detected",
+				Title:       title,
 				Description: "A HashiCorp Vault token was found. " +
 					"Vault tokens provide authenticated access to secrets stored in Vault.",
 				Message: fmt.Sprintf("A Vault token was detected in %s.", ctx.FormatSource()),


### PR DESCRIPTION
  Makes Finding ID and Title one-to-one across all secret detectors, so each ID uniquely identifies a single Title (and vice versa). This is required for downstream ingestion, which keys findings by ID and expects a stable,
   unambiguous Title per ID.

  Previously, several detectors reused a single generic Title across many tokenType-derived IDs (e.g. all 6 GitHub PAT variants shared "GitHub Token Detected", all 6 cloud credential variants shared "Cloud Credential
  Detected", etc.).