### PR TITLE
add slack, stripe, twilio, and database connection string detectors

### DIFF
--- a/cmd/bagel/scan.go
+++ b/cmd/bagel/scan.go
@@ -121,6 +121,10 @@ func initializeProbes(cfg *models.Config) []probe.Probe {
 	registry.Register(detector.NewPyPITokenDetector())
 	registry.Register(detector.NewWireGuardKeyDetector())
 	registry.Register(detector.NewSplunkTokenDetector())
+	registry.Register(detector.NewDatabaseConnectionDetector())
+	registry.Register(detector.NewSlackTokenDetector())
+	registry.Register(detector.NewStripeKeyDetector())
+	registry.Register(detector.NewTwilioKeyDetector())
 	registry.Register(detector.NewGenericAPIKeyDetector())
 	registry.Register(detector.NewJWTDetector())
 	// Add more detectors here as they are implemented:

--- a/cmd/bagel/scrub.go
+++ b/cmd/bagel/scrub.go
@@ -96,6 +96,10 @@ func newScrubRegistry() *detector.Registry {
 	registry.Register(detector.NewVaultTokenDetector())
 	registry.Register(detector.NewPyPITokenDetector())
 	registry.Register(detector.NewWireGuardKeyDetector())
+	registry.Register(detector.NewDatabaseConnectionDetector())
+	registry.Register(detector.NewSlackTokenDetector())
+	registry.Register(detector.NewStripeKeyDetector())
+	registry.Register(detector.NewTwilioKeyDetector())
 	registry.Register(detector.NewJWTDetector())
 	registry.Register(detector.NewGenericAPIKeyDetector())
 	return registry

--- a/pkg/detector/database_connection.go
+++ b/pkg/detector/database_connection.go
@@ -1,0 +1,107 @@
+// Copyright (C) 2026 boostsecurity.io
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package detector
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/boostsecurityio/bagel/pkg/models"
+)
+
+// DatabaseConnectionDetector detects database connection URLs that embed
+// credentials in the userinfo segment (e.g. postgres://user:pw@host/db).
+// URLs without an embedded password (postgres://host/db,
+// postgres://user@host/db) are not credentials and not reported.
+type DatabaseConnectionDetector struct {
+	pattern        *regexp.Regexp
+	redactPatterns []RedactPattern
+}
+
+// dbConnectionRegex matches <scheme>://[user]:password@host[:port][/path]
+// for the database/queue schemes most commonly seen in dev configs.
+// The userinfo half allows an empty username (e.g. redis://:pw@host) but
+// requires a non-empty password — that's the bit that makes it a credential.
+var dbConnectionRegex = regexp.MustCompile(
+	`\b(postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|rediss?|amqps?|clickhouse|mssql)://` +
+		`([^:@/\s"'<>]*):([^@/\s"'<>]+)@` +
+		`([^/\s"'<>?#]+)`,
+)
+
+// NewDatabaseConnectionDetector creates a new database connection URL detector.
+func NewDatabaseConnectionDetector() *DatabaseConnectionDetector {
+	return &DatabaseConnectionDetector{
+		pattern: dbConnectionRegex,
+		redactPatterns: []RedactPattern{
+			{
+				// Preserve scheme://user@host so the redacted file is
+				// still readable; only the password vanishes.
+				Regex:       dbConnectionRegex,
+				Replacement: `${1}://${2}:[REDACTED-db-credential]@${4}`,
+				Label:       "REDACTED-db-credential",
+				Prefixes: []string{
+					"postgres://", "postgresql://", "mysql://", "mariadb://",
+					"mongodb://", "mongodb+srv://", "redis://", "rediss://",
+					"amqp://", "amqps://", "clickhouse://", "mssql://",
+				},
+			},
+		},
+	}
+}
+
+// Name returns the detector name.
+func (d *DatabaseConnectionDetector) Name() string {
+	return "database-connection-string"
+}
+
+// Detect scans content for database connection URLs with embedded
+// passwords and returns findings.
+func (d *DatabaseConnectionDetector) Detect(
+	content string,
+	ctx *models.DetectionContext,
+) []models.Finding {
+	matches := d.pattern.FindAllStringSubmatch(content, -1)
+	findings := make([]models.Finding, 0, len(matches))
+	seen := make(map[string]bool, len(matches))
+
+	for _, m := range matches {
+		full := m[0]
+		if seen[full] {
+			continue
+		}
+		seen[full] = true
+
+		scheme := strings.ToLower(m[1])
+		username := m[2]
+		host := m[4]
+
+		findings = append(findings, models.Finding{
+			ID:          "database-connection-string",
+			Type:        models.FindingTypeSecret,
+			Fingerprint: models.SaltedFingerprint(full, ctx.FingerprintSalt),
+			Severity:    "critical",
+			Title:       "Database Connection String With Embedded Credential Detected",
+			Description: "A database/queue connection URL embeds a password in the userinfo segment. " +
+				"Move the credential to a secret manager or env variable referenced by the URL " +
+				"(some clients support ${ENV} expansion).",
+			Message: fmt.Sprintf("A %s connection string with embedded credentials was detected in %s.",
+				scheme, ctx.FormatSource()),
+			Path: ctx.Source,
+			Metadata: map[string]interface{}{
+				"detector_name":    d.Name(),
+				"scheme":           scheme,
+				"host":             host,
+				"username_present": username != "",
+			},
+		})
+	}
+	return findings
+}
+
+// Redact replaces password components in detected URLs with a redaction
+// marker, leaving scheme/user/host intact.
+func (d *DatabaseConnectionDetector) Redact(content string) (string, map[string]int) {
+	return ApplyRedactPatterns(content, d.redactPatterns)
+}

--- a/pkg/detector/database_connection.go
+++ b/pkg/detector/database_connection.go
@@ -24,8 +24,10 @@ type DatabaseConnectionDetector struct {
 // for the database/queue schemes most commonly seen in dev configs.
 // The userinfo half allows an empty username (e.g. redis://:pw@host) but
 // requires a non-empty password — that's the bit that makes it a credential.
+// Case-insensitive because URL schemes are case-insensitive per RFC 3986
+// (e.g. POSTGRES://… is valid).
 var dbConnectionRegex = regexp.MustCompile(
-	`\b(postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|rediss?|amqps?|clickhouse|mssql)://` +
+	`(?i)\b(postgres(?:ql)?|mysql|mariadb|mongodb(?:\+srv)?|rediss?|amqps?|clickhouse|mssql)://` +
 		`([^:@/\s"'<>]*):([^@/\s"'<>]+)@` +
 		`([^/\s"'<>?#]+)`,
 )
@@ -41,11 +43,11 @@ func NewDatabaseConnectionDetector() *DatabaseConnectionDetector {
 				Regex:       dbConnectionRegex,
 				Replacement: `${1}://${2}:[REDACTED-db-credential]@${4}`,
 				Label:       "REDACTED-db-credential",
-				Prefixes: []string{
-					"postgres://", "postgresql://", "mysql://", "mariadb://",
-					"mongodb://", "mongodb+srv://", "redis://", "rediss://",
-					"amqp://", "amqps://", "clickhouse://", "mssql://",
-				},
+				// `://` works as a case-insensitive fast-path gate for
+				// every supported scheme; enumerating each lowercase
+				// scheme would miss uppercase/mixed-case variants the
+				// regex above happily detects.
+				Prefixes: []string{"://"},
 			},
 		},
 	}

--- a/pkg/detector/database_connection_test.go
+++ b/pkg/detector/database_connection_test.go
@@ -100,6 +100,20 @@ db2=mysql://c:d@h2/e`,
 			content:   `postgres://a:b@h/d postgres://a:b@h/d`,
 			wantCount: 1,
 		},
+		{
+			name:       "uppercase scheme is detected (RFC 3986 schemes are case-insensitive)",
+			content:    `DATABASE_URL=POSTGRES://alice:hunter2@db.example.com:5432/app`,
+			wantCount:  1,
+			wantScheme: "postgres",
+			wantHost:   "db.example.com:5432",
+		},
+		{
+			name:       "mixed-case scheme is detected and scheme metadata is normalized",
+			content:    `MySQL://root:rootpw@localhost:3306/mydb`,
+			wantCount:  1,
+			wantScheme: "mysql",
+			wantHost:   "localhost:3306",
+		},
 	}
 
 	for _, tt := range tests {
@@ -143,6 +157,12 @@ func TestDatabaseConnectionDetector_Redact(t *testing.T) {
 			input:   "postgres://localhost/db",
 			want:    "postgres://localhost/db",
 			wantHit: false,
+		},
+		{
+			name:    "uppercase scheme is redacted too",
+			input:   "DB=POSTGRES://alice:hunter2@db.example.com:5432/app",
+			want:    "DB=POSTGRES://alice:[REDACTED-db-credential]@db.example.com:5432/app",
+			wantHit: true,
 		},
 	}
 

--- a/pkg/detector/database_connection_test.go
+++ b/pkg/detector/database_connection_test.go
@@ -1,0 +1,164 @@
+// Copyright (C) 2026 boostsecurity.io
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package detector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDatabaseConnectionDetector_Detect(t *testing.T) {
+	det := NewDatabaseConnectionDetector()
+
+	tests := []struct {
+		name       string
+		content    string
+		wantCount  int
+		wantScheme string
+		wantHost   string
+	}{
+		{
+			name:       "postgres URL with user and password",
+			content:    `DATABASE_URL=postgres://alice:hunter2@db.example.com:5432/app`,
+			wantCount:  1,
+			wantScheme: "postgres",
+			wantHost:   "db.example.com:5432",
+		},
+		{
+			name:       "postgresql alternate scheme",
+			content:    `DATABASE_URL=postgresql://u:p@h/d`,
+			wantCount:  1,
+			wantScheme: "postgresql",
+			wantHost:   "h",
+		},
+		{
+			name:       "mysql URL",
+			content:    `mysql://root:rootpw@localhost:3306/mydb`,
+			wantCount:  1,
+			wantScheme: "mysql",
+			wantHost:   "localhost:3306",
+		},
+		{
+			name:       "mongodb+srv URL",
+			content:    `mongodb+srv://user:pw@cluster0.example.mongodb.net/db?retryWrites=true`,
+			wantCount:  1,
+			wantScheme: "mongodb+srv",
+			wantHost:   "cluster0.example.mongodb.net",
+		},
+		{
+			name:       "redis URL with password only",
+			content:    `redis://:supersecret@redis.internal:6379/0`,
+			wantCount:  1,
+			wantScheme: "redis",
+			wantHost:   "redis.internal:6379",
+		},
+		{
+			name:       "rediss URL (TLS)",
+			content:    `REDIS_URL=rediss://default:abc123@cache.example.com:6380`,
+			wantCount:  1,
+			wantScheme: "rediss",
+			wantHost:   "cache.example.com:6380",
+		},
+		{
+			name:       "amqps URL",
+			content:    `amqps://broker:brokerpw@rabbit.example.com:5671/vhost`,
+			wantCount:  1,
+			wantScheme: "amqps",
+			wantHost:   "rabbit.example.com:5671",
+		},
+		{
+			name:      "no userinfo — not a credential",
+			content:   `postgres://localhost/mydb`,
+			wantCount: 0,
+		},
+		{
+			name:      "username only, no password — not a credential",
+			content:   `postgres://alice@db.example.com/app`,
+			wantCount: 0,
+		},
+		{
+			name:      "http URL is not a database scheme",
+			content:   `https://user:pw@api.example.com/path`,
+			wantCount: 0,
+		},
+		{
+			name:      "no schemes at all",
+			content:   `JUST_A_REGULAR_STRING=hello`,
+			wantCount: 0,
+		},
+		{
+			name: "multiple URLs in one document",
+			content: `db1=postgres://a:b@h1/d
+db2=mysql://c:d@h2/e`,
+			wantCount: 2,
+		},
+		{
+			name:      "duplicate URLs collapse to one finding",
+			content:   `postgres://a:b@h/d postgres://a:b@h/d`,
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := det.Detect(tt.content, testCtx("env:DATABASE_URL"))
+			require.Len(t, findings, tt.wantCount)
+			if tt.wantCount > 0 && tt.wantScheme != "" {
+				f := findings[0]
+				assert.Equal(t, "database-connection-string", f.ID)
+				assert.Equal(t, "critical", f.Severity)
+				assert.Equal(t, tt.wantScheme, f.Metadata["scheme"])
+				assert.Equal(t, tt.wantHost, f.Metadata["host"])
+			}
+		})
+	}
+}
+
+func TestDatabaseConnectionDetector_Redact(t *testing.T) {
+	det := NewDatabaseConnectionDetector()
+
+	tests := []struct {
+		name    string
+		input   string
+		want    string
+		wantHit bool
+	}{
+		{
+			name:    "redact password preserves scheme/user/host",
+			input:   "DATABASE_URL=postgres://alice:hunter2@db.example.com:5432/app",
+			want:    "DATABASE_URL=postgres://alice:[REDACTED-db-credential]@db.example.com:5432/app",
+			wantHit: true,
+		},
+		{
+			name:    "redact password-only redis URL",
+			input:   "redis://:s3cr3t@cache:6379",
+			want:    "redis://:[REDACTED-db-credential]@cache:6379",
+			wantHit: true,
+		},
+		{
+			name:    "URL without password is untouched",
+			input:   "postgres://localhost/db",
+			want:    "postgres://localhost/db",
+			wantHit: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, counts := det.Redact(tt.input)
+			assert.Equal(t, tt.want, out)
+			if tt.wantHit {
+				assert.Equal(t, 1, counts["REDACTED-db-credential"])
+			} else {
+				assert.Zero(t, counts["REDACTED-db-credential"])
+			}
+		})
+	}
+}
+
+func TestDatabaseConnectionDetector_Name(t *testing.T) {
+	assert.Equal(t, "database-connection-string", NewDatabaseConnectionDetector().Name())
+}

--- a/pkg/detector/slack_token.go
+++ b/pkg/detector/slack_token.go
@@ -63,10 +63,12 @@ func (d *SlackTokenDetector) Detect(
 	content string,
 	ctx *models.DetectionContext,
 ) []models.Finding {
-	var findings []models.Finding
+	wsMatches := d.workspacePattern.FindAllStringSubmatch(content, -1)
+	appMatches := d.appPattern.FindAllStringSubmatch(content, -1)
+	findings := make([]models.Finding, 0, len(wsMatches)+len(appMatches))
 	seen := make(map[string]bool)
 
-	for _, m := range d.workspacePattern.FindAllStringSubmatch(content, -1) {
+	for _, m := range wsMatches {
 		token := m[1]
 		if seen[token] {
 			continue
@@ -74,7 +76,7 @@ func (d *SlackTokenDetector) Detect(
 		seen[token] = true
 		findings = append(findings, d.makeFinding(token, slackPrefixClass(token), ctx))
 	}
-	for _, m := range d.appPattern.FindAllStringSubmatch(content, -1) {
+	for _, m := range appMatches {
 		token := m[1]
 		if seen[token] {
 			continue

--- a/pkg/detector/slack_token.go
+++ b/pkg/detector/slack_token.go
@@ -1,0 +1,135 @@
+// Copyright (C) 2026 boostsecurity.io
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package detector
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/boostsecurityio/bagel/pkg/models"
+)
+
+// SlackTokenDetector detects Slack workspace and app-level tokens.
+//
+// Slack tokens come in two prefix families:
+//
+//   - xox[abprs]- — bot (b), legacy app (a), user (p), refresh (r),
+//     session/workspace (s). Body is base32-ish with dashes.
+//   - xapp-      — app-level tokens used by Socket Mode connections.
+//
+// All variants grant API access to a Slack workspace; treat them all
+// as critical.
+type SlackTokenDetector struct {
+	workspacePattern *regexp.Regexp
+	appPattern       *regexp.Regexp
+	redactPatterns   []RedactPattern
+}
+
+// NewSlackTokenDetector creates a new Slack token detector.
+func NewSlackTokenDetector() *SlackTokenDetector {
+	// 10+ body chars is a deliberate floor — short prefixes alone
+	// produce too many false positives in code that mentions Slack
+	// without containing real tokens.
+	workspace := regexp.MustCompile(`\b(xox[abprs]-[A-Za-z0-9-]{10,})\b`)
+	app := regexp.MustCompile(`\b(xapp-[A-Za-z0-9-]{10,})\b`)
+	return &SlackTokenDetector{
+		workspacePattern: workspace,
+		appPattern:       app,
+		redactPatterns: []RedactPattern{
+			{
+				Regex:       workspace,
+				Replacement: `[REDACTED-slack-token]`,
+				Label:       "REDACTED-slack-token",
+				Prefixes:    []string{"xoxa-", "xoxb-", "xoxp-", "xoxr-", "xoxs-"},
+			},
+			{
+				Regex:       app,
+				Replacement: `[REDACTED-slack-token]`,
+				Label:       "REDACTED-slack-token",
+				Prefixes:    []string{"xapp-"},
+			},
+		},
+	}
+}
+
+// Name returns the detector name.
+func (d *SlackTokenDetector) Name() string {
+	return "slack-token"
+}
+
+// Detect scans content for Slack tokens and returns findings.
+func (d *SlackTokenDetector) Detect(
+	content string,
+	ctx *models.DetectionContext,
+) []models.Finding {
+	var findings []models.Finding
+	seen := make(map[string]bool)
+
+	for _, m := range d.workspacePattern.FindAllStringSubmatch(content, -1) {
+		token := m[1]
+		if seen[token] {
+			continue
+		}
+		seen[token] = true
+		findings = append(findings, d.makeFinding(token, slackPrefixClass(token), ctx))
+	}
+	for _, m := range d.appPattern.FindAllStringSubmatch(content, -1) {
+		token := m[1]
+		if seen[token] {
+			continue
+		}
+		seen[token] = true
+		findings = append(findings, d.makeFinding(token, "app", ctx))
+	}
+	return findings
+}
+
+// Redact replaces Slack tokens in content with redaction markers.
+func (d *SlackTokenDetector) Redact(content string) (string, map[string]int) {
+	return ApplyRedactPatterns(content, d.redactPatterns)
+}
+
+// slackPrefixClass maps a token's prefix to its Slack-documented class
+// (bot/user/app/refresh/session). The 4th byte of an `xox*-` token is
+// the class character; callers must only pass tokens that matched
+// workspacePattern.
+func slackPrefixClass(token string) string {
+	switch token[3] {
+	case 'a':
+		return "legacy-app"
+	case 'b':
+		return "bot"
+	case 'p':
+		return "user"
+	case 'r':
+		return "refresh"
+	case 's':
+		return "session"
+	default:
+		return "workspace"
+	}
+}
+
+func (d *SlackTokenDetector) makeFinding(
+	token string,
+	class string,
+	ctx *models.DetectionContext,
+) models.Finding {
+	return models.Finding{
+		ID:          "slack-token",
+		Type:        models.FindingTypeSecret,
+		Fingerprint: models.SaltedFingerprint(token, ctx.FingerprintSalt),
+		Severity:    "critical",
+		Title:       "Slack Token Detected",
+		Description: "A Slack token grants API access to a Slack workspace " +
+			"(read messages, post as the token's identity, manage the workspace " +
+			"depending on scope). Revoke it from the Slack admin console.",
+		Message: fmt.Sprintf("A Slack %s token was detected in %s.", class, ctx.FormatSource()),
+		Path:    ctx.Source,
+		Metadata: map[string]interface{}{
+			"detector_name": d.Name(),
+			"token_class":   class,
+		},
+	}
+}

--- a/pkg/detector/slack_token_test.go
+++ b/pkg/detector/slack_token_test.go
@@ -1,0 +1,120 @@
+// Copyright (C) 2026 boostsecurity.io
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package detector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSlackTokenDetector_Detect(t *testing.T) {
+	det := NewSlackTokenDetector()
+
+	tests := []struct {
+		name      string
+		content   string
+		wantCount int
+		wantClass string
+	}{
+		{
+			name:      "bot token",
+			content:   `SLACK_BOT_TOKEN=xoxb-123456789012-345678901234-abcdef0123456789ABCDEFGH`,
+			wantCount: 1,
+			wantClass: "bot",
+		},
+		{
+			name:      "user token",
+			content:   `xoxp-1234567890-987654321-abcdefghijklmnop`,
+			wantCount: 1,
+			wantClass: "user",
+		},
+		{
+			name:      "legacy app token",
+			content:   `legacy=xoxa-1234567890abcdef`,
+			wantCount: 1,
+			wantClass: "legacy-app",
+		},
+		{
+			name:      "refresh token",
+			content:   `xoxr-1234567890abcdef-extra`,
+			wantCount: 1,
+			wantClass: "refresh",
+		},
+		{
+			name:      "app-level token (Socket Mode)",
+			content:   `xapp-1-A0123456789-1234567890123-abcdef0123456789`,
+			wantCount: 1,
+			wantClass: "app",
+		},
+		{
+			name:      "short prefix without enough body — ignored",
+			content:   `xoxb-short`,
+			wantCount: 0,
+		},
+		{
+			name:      "non-token text mentioning Slack",
+			content:   `slack token rotation procedure`,
+			wantCount: 0,
+		},
+		{
+			name: "duplicate token collapses to one finding",
+			content: `first xoxb-1111111111-2222222222-aaaaaaaaaaaaaaaaaaaaaaaa
+second xoxb-1111111111-2222222222-aaaaaaaaaaaaaaaaaaaaaaaa`,
+			wantCount: 1,
+			wantClass: "bot",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := det.Detect(tt.content, testCtx("env:SLACK_BOT_TOKEN"))
+			require.Len(t, findings, tt.wantCount)
+			if tt.wantCount > 0 {
+				f := findings[0]
+				assert.Equal(t, "slack-token", f.ID)
+				assert.Equal(t, "critical", f.Severity)
+				assert.Equal(t, tt.wantClass, f.Metadata["token_class"])
+			}
+		})
+	}
+}
+
+func TestSlackTokenDetector_Redact(t *testing.T) {
+	det := NewSlackTokenDetector()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "redact xoxb",
+			input: "TOKEN=xoxb-1-2-aaaaaaaaaaaaaaaaaaaaaaaaa",
+			want:  "TOKEN=[REDACTED-slack-token]",
+		},
+		{
+			name:  "redact xapp",
+			input: "APP=xapp-1-A0-1234567890-aaaaaaaaaaaaaaaaaaaaaaaa",
+			want:  "APP=[REDACTED-slack-token]",
+		},
+		{
+			name:  "no token — untouched",
+			input: "regular text",
+			want:  "regular text",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, _ := det.Redact(tt.input)
+			assert.Equal(t, tt.want, out)
+		})
+	}
+}
+
+func TestSlackTokenDetector_Name(t *testing.T) {
+	assert.Equal(t, "slack-token", NewSlackTokenDetector().Name())
+}

--- a/pkg/detector/stripe_key.go
+++ b/pkg/detector/stripe_key.go
@@ -1,0 +1,163 @@
+// Copyright (C) 2026 boostsecurity.io
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package detector
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/boostsecurityio/bagel/pkg/models"
+)
+
+// StripeKeyDetector detects Stripe API keys. Stripe uses three prefix
+// families:
+//
+//   - sk_(live|test)_…  — Secret key. Full Stripe API access (live), or
+//     test-mode access (test).
+//   - rk_(live|test)_…  — Restricted key. Same shape as sk_, scoped by
+//     roles configured in the Stripe dashboard.
+//   - pk_(live|test)_…  — Publishable key. Not a secret per Stripe
+//     (designed to ship in client-side JS), but worth surfacing because
+//     leaking it can enable fraudulent Element/Checkout usage and
+//     people frequently confuse it with the secret key.
+//
+// IDs split secret vs publishable so callers can filter; severities
+// reflect how much damage a leaked key enables.
+type StripeKeyDetector struct {
+	secretPattern      *regexp.Regexp
+	restrictedPattern  *regexp.Regexp
+	publishablePattern *regexp.Regexp
+	redactPatterns     []RedactPattern
+}
+
+// NewStripeKeyDetector creates a new Stripe API key detector.
+func NewStripeKeyDetector() *StripeKeyDetector {
+	// Stripe keys are alphanumeric after the prefix. 24 chars is the
+	// shortest observed body; live keys are typically 100+, test keys
+	// 24+. Loosen to 24 to also catch older keys still in circulation.
+	secret := regexp.MustCompile(`\b(sk_(live|test)_[A-Za-z0-9]{24,})\b`)
+	restricted := regexp.MustCompile(`\b(rk_(live|test)_[A-Za-z0-9]{24,})\b`)
+	publishable := regexp.MustCompile(`\b(pk_(live|test)_[A-Za-z0-9]{24,})\b`)
+	return &StripeKeyDetector{
+		secretPattern:      secret,
+		restrictedPattern:  restricted,
+		publishablePattern: publishable,
+		// Redact only secret + restricted. Publishable keys are
+		// intentionally exposed (web pages, mobile apps); redacting
+		// them in shared logs/scrubs would break legitimate uses.
+		redactPatterns: []RedactPattern{
+			{
+				Regex:       secret,
+				Replacement: `[REDACTED-stripe-secret-key]`,
+				Label:       "REDACTED-stripe-secret-key",
+				Prefixes:    []string{"sk_live_", "sk_test_"},
+			},
+			{
+				Regex:       restricted,
+				Replacement: `[REDACTED-stripe-secret-key]`,
+				Label:       "REDACTED-stripe-secret-key",
+				Prefixes:    []string{"rk_live_", "rk_test_"},
+			},
+		},
+	}
+}
+
+// Name returns the detector name.
+func (d *StripeKeyDetector) Name() string {
+	return "stripe-key"
+}
+
+// Detect scans content for Stripe API keys and returns findings.
+func (d *StripeKeyDetector) Detect(
+	content string,
+	ctx *models.DetectionContext,
+) []models.Finding {
+	var findings []models.Finding
+	seen := make(map[string]bool)
+
+	type variant struct {
+		pattern    *regexp.Regexp
+		id         string
+		title      string
+		descPrefix string
+		liveSev    string
+		testSev    string
+	}
+	variants := []variant{
+		{
+			pattern:    d.secretPattern,
+			id:         "stripe-secret-key",
+			title:      "Stripe Secret Key Detected",
+			descPrefix: "Stripe secret key — full API access to the Stripe account.",
+			liveSev:    "critical",
+			testSev:    "high",
+		},
+		{
+			pattern:    d.restrictedPattern,
+			id:         "stripe-secret-key",
+			title:      "Stripe Restricted Key Detected",
+			descPrefix: "Stripe restricted key — scoped API access set in the dashboard.",
+			liveSev:    "critical",
+			testSev:    "high",
+		},
+		{
+			pattern: d.publishablePattern,
+			id:      "stripe-publishable-key",
+			title:   "Stripe Publishable Key Detected",
+			descPrefix: "Stripe publishable key — designed to ship in client-side code, " +
+				"so not strictly a secret, but a leak can enable fraudulent Checkout/Element use.",
+			liveSev: "low",
+			testSev: "low",
+		},
+	}
+
+	for _, v := range variants {
+		for _, m := range v.pattern.FindAllStringSubmatch(content, -1) {
+			token := m[1]
+			env := m[2] // "live" or "test"
+			if seen[token] {
+				continue
+			}
+			seen[token] = true
+
+			severity := v.liveSev
+			if env == "test" {
+				severity = v.testSev
+			}
+
+			findings = append(findings, models.Finding{
+				ID:          v.id,
+				Type:        models.FindingTypeSecret,
+				Fingerprint: models.SaltedFingerprint(token, ctx.FingerprintSalt),
+				Severity:    severity,
+				Title:       v.title,
+				Description: v.descPrefix + " Rotate the key from the Stripe dashboard.",
+				Message:     fmt.Sprintf("A Stripe %s key (%s mode) was detected in %s.", keyKind(v.id), env, ctx.FormatSource()),
+				Path:        ctx.Source,
+				Metadata: map[string]interface{}{
+					"detector_name": d.Name(),
+					"key_kind":      keyKind(v.id),
+					"environment":   env,
+				},
+			})
+		}
+	}
+	return findings
+}
+
+// Redact replaces Stripe secret/restricted keys with redaction markers.
+// Publishable keys are intentionally left alone.
+func (d *StripeKeyDetector) Redact(content string) (string, map[string]int) {
+	return ApplyRedactPatterns(content, d.redactPatterns)
+}
+
+// keyKind returns the human-readable kind ("secret"/"restricted"/
+// "publishable") corresponding to a finding ID. Used in messages and
+// metadata for at-a-glance triage.
+func keyKind(findingID string) string {
+	if findingID == "stripe-publishable-key" {
+		return "publishable"
+	}
+	return "secret"
+}

--- a/pkg/detector/stripe_key.go
+++ b/pkg/detector/stripe_key.go
@@ -76,9 +76,14 @@ func (d *StripeKeyDetector) Detect(
 	findings := make([]models.Finding, 0, 4)
 	seen := make(map[string]bool)
 
+	// kind is the human-readable variant label ("secret" / "restricted"
+	// / "publishable"). It's tracked explicitly so the message/metadata
+	// reflect the actual key family — secret and restricted share a
+	// finding ID for filter convenience, so we can't derive kind from ID.
 	type variant struct {
 		pattern    *regexp.Regexp
 		id         string
+		kind       string
 		title      string
 		descPrefix string
 		liveSev    string
@@ -88,6 +93,7 @@ func (d *StripeKeyDetector) Detect(
 		{
 			pattern:    d.secretPattern,
 			id:         "stripe-secret-key",
+			kind:       "secret",
 			title:      "Stripe Secret Key Detected",
 			descPrefix: "Stripe secret key — full API access to the Stripe account.",
 			liveSev:    "critical",
@@ -96,6 +102,7 @@ func (d *StripeKeyDetector) Detect(
 		{
 			pattern:    d.restrictedPattern,
 			id:         "stripe-secret-key",
+			kind:       "restricted",
 			title:      "Stripe Restricted Key Detected",
 			descPrefix: "Stripe restricted key — scoped API access set in the dashboard.",
 			liveSev:    "critical",
@@ -104,6 +111,7 @@ func (d *StripeKeyDetector) Detect(
 		{
 			pattern: d.publishablePattern,
 			id:      "stripe-publishable-key",
+			kind:    "publishable",
 			title:   "Stripe Publishable Key Detected",
 			descPrefix: "Stripe publishable key — designed to ship in client-side code, " +
 				"so not strictly a secret, but a leak can enable fraudulent Checkout/Element use.",
@@ -133,11 +141,11 @@ func (d *StripeKeyDetector) Detect(
 				Severity:    severity,
 				Title:       v.title,
 				Description: v.descPrefix + " Rotate the key from the Stripe dashboard.",
-				Message:     fmt.Sprintf("A Stripe %s key (%s mode) was detected in %s.", keyKind(v.id), env, ctx.FormatSource()),
+				Message:     fmt.Sprintf("A Stripe %s key (%s mode) was detected in %s.", v.kind, env, ctx.FormatSource()),
 				Path:        ctx.Source,
 				Metadata: map[string]interface{}{
 					"detector_name": d.Name(),
-					"key_kind":      keyKind(v.id),
+					"key_kind":      v.kind,
 					"environment":   env,
 				},
 			})
@@ -150,14 +158,4 @@ func (d *StripeKeyDetector) Detect(
 // Publishable keys are intentionally left alone.
 func (d *StripeKeyDetector) Redact(content string) (string, map[string]int) {
 	return ApplyRedactPatterns(content, d.redactPatterns)
-}
-
-// keyKind returns the human-readable kind ("secret"/"restricted"/
-// "publishable") corresponding to a finding ID. Used in messages and
-// metadata for at-a-glance triage.
-func keyKind(findingID string) string {
-	if findingID == "stripe-publishable-key" {
-		return "publishable"
-	}
-	return "secret"
 }

--- a/pkg/detector/stripe_key.go
+++ b/pkg/detector/stripe_key.go
@@ -73,7 +73,7 @@ func (d *StripeKeyDetector) Detect(
 	content string,
 	ctx *models.DetectionContext,
 ) []models.Finding {
-	var findings []models.Finding
+	findings := make([]models.Finding, 0, 4)
 	seen := make(map[string]bool)
 
 	type variant struct {

--- a/pkg/detector/stripe_key_test.go
+++ b/pkg/detector/stripe_key_test.go
@@ -41,12 +41,22 @@ func TestStripeKeyDetector_Detect(t *testing.T) {
 			wantCount: 1,
 		},
 		{
-			name:      "live restricted key",
+			name: "live restricted key (kind preserved, ID grouped with secret " +
+				"for filter convenience)",
 			content:   "key=rk_live_abcdefghijklmnopqrstuvwx",
 			wantID:    "stripe-secret-key",
-			wantKind:  "secret",
+			wantKind:  "restricted",
 			wantEnv:   "live",
 			wantSev:   "critical",
+			wantCount: 1,
+		},
+		{
+			name:      "test restricted key",
+			content:   "key=rk_test_abcdefghijklmnopqrstuvwx",
+			wantID:    "stripe-secret-key",
+			wantKind:  "restricted",
+			wantEnv:   "test",
+			wantSev:   "high",
 			wantCount: 1,
 		},
 		{

--- a/pkg/detector/stripe_key_test.go
+++ b/pkg/detector/stripe_key_test.go
@@ -1,0 +1,129 @@
+// Copyright (C) 2026 boostsecurity.io
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package detector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStripeKeyDetector_Detect(t *testing.T) {
+	det := NewStripeKeyDetector()
+
+	tests := []struct {
+		name      string
+		content   string
+		wantID    string
+		wantKind  string
+		wantEnv   string
+		wantSev   string
+		wantCount int
+	}{
+		{
+			name:      "live secret key",
+			content:   "STRIPE_SECRET_KEY=sk_live_abcdefghijklmnopqrstuvwx",
+			wantID:    "stripe-secret-key",
+			wantKind:  "secret",
+			wantEnv:   "live",
+			wantSev:   "critical",
+			wantCount: 1,
+		},
+		{
+			name:      "test secret key",
+			content:   "STRIPE_SECRET_KEY=sk_test_abcdefghijklmnopqrstuvwx",
+			wantID:    "stripe-secret-key",
+			wantKind:  "secret",
+			wantEnv:   "test",
+			wantSev:   "high",
+			wantCount: 1,
+		},
+		{
+			name:      "live restricted key",
+			content:   "key=rk_live_abcdefghijklmnopqrstuvwx",
+			wantID:    "stripe-secret-key",
+			wantKind:  "secret",
+			wantEnv:   "live",
+			wantSev:   "critical",
+			wantCount: 1,
+		},
+		{
+			name:      "live publishable key — informational",
+			content:   "STRIPE_PUB=pk_live_abcdefghijklmnopqrstuvwx",
+			wantID:    "stripe-publishable-key",
+			wantKind:  "publishable",
+			wantEnv:   "live",
+			wantSev:   "low",
+			wantCount: 1,
+		},
+		{
+			name:      "no Stripe key — sk_other_ prefix is not a stripe key",
+			content:   "sk_other_abcdefghijklmnopqrstuvwx",
+			wantCount: 0,
+		},
+		{
+			name:      "too short body — not a Stripe key",
+			content:   "sk_live_short",
+			wantCount: 0,
+		},
+		{
+			name: "secret + publishable in same file produces two findings",
+			content: `STRIPE_SECRET_KEY=sk_live_aaaaaaaaaaaaaaaaaaaaaaaa
+STRIPE_PUB_KEY=pk_live_bbbbbbbbbbbbbbbbbbbbbbbb`,
+			wantCount: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := det.Detect(tt.content, testCtx("env:STRIPE"))
+			require.Len(t, findings, tt.wantCount)
+			if tt.wantCount == 1 {
+				f := findings[0]
+				assert.Equal(t, tt.wantID, f.ID)
+				assert.Equal(t, tt.wantSev, f.Severity)
+				assert.Equal(t, tt.wantKind, f.Metadata["key_kind"])
+				assert.Equal(t, tt.wantEnv, f.Metadata["environment"])
+			}
+		})
+	}
+}
+
+func TestStripeKeyDetector_Redact(t *testing.T) {
+	det := NewStripeKeyDetector()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "secret key redacted",
+			input: "k=sk_live_abcdefghijklmnopqrstuvwx",
+			want:  "k=[REDACTED-stripe-secret-key]",
+		},
+		{
+			name:  "restricted key redacted",
+			input: "k=rk_test_abcdefghijklmnopqrstuvwx",
+			want:  "k=[REDACTED-stripe-secret-key]",
+		},
+		{
+			name:  "publishable key NOT redacted (meant to be public)",
+			input: "k=pk_live_abcdefghijklmnopqrstuvwx",
+			want:  "k=pk_live_abcdefghijklmnopqrstuvwx",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, _ := det.Redact(tt.input)
+			assert.Equal(t, tt.want, out)
+		})
+	}
+}
+
+func TestStripeKeyDetector_Name(t *testing.T) {
+	assert.Equal(t, "stripe-key", NewStripeKeyDetector().Name())
+}

--- a/pkg/detector/twilio_key.go
+++ b/pkg/detector/twilio_key.go
@@ -1,0 +1,93 @@
+// Copyright (C) 2026 boostsecurity.io
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package detector
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/boostsecurityio/bagel/pkg/models"
+)
+
+// TwilioKeyDetector detects Twilio API Key SIDs.
+//
+// The SID itself (SK + 32 hex) is an identifier, not a secret. The
+// paired auth token (32 hex chars, no fixed prefix) is the actual
+// credential — but a bare 32-hex string is too ambiguous to detect
+// directly without producing huge volumes of false positives. By
+// surfacing the SID we give the user a strong starting point: the
+// matching token typically lives in the same file or env block.
+//
+// We deliberately skip Account SIDs (AC + 32 hex). They identify the
+// account but, like the API Key SID, aren't secrets; reporting both
+// just doubles the noise without adding signal.
+type TwilioKeyDetector struct {
+	pattern        *regexp.Regexp
+	redactPatterns []RedactPattern
+}
+
+// NewTwilioKeyDetector creates a new Twilio API Key SID detector.
+func NewTwilioKeyDetector() *TwilioKeyDetector {
+	pattern := regexp.MustCompile(`\b(SK[0-9a-fA-F]{32})\b`)
+	return &TwilioKeyDetector{
+		pattern: pattern,
+		redactPatterns: []RedactPattern{
+			{
+				Regex:       pattern,
+				Replacement: `[REDACTED-twilio-api-key-sid]`,
+				Label:       "REDACTED-twilio-api-key-sid",
+				Prefixes:    []string{"SK"},
+			},
+		},
+	}
+}
+
+// Name returns the detector name.
+func (d *TwilioKeyDetector) Name() string {
+	return "twilio-key"
+}
+
+// Detect scans content for Twilio API Key SIDs and returns findings.
+func (d *TwilioKeyDetector) Detect(
+	content string,
+	ctx *models.DetectionContext,
+) []models.Finding {
+	matches := d.pattern.FindAllString(content, -1)
+	findings := make([]models.Finding, 0, len(matches))
+	seen := make(map[string]bool, len(matches))
+
+	for _, sid := range matches {
+		if seen[sid] {
+			continue
+		}
+		seen[sid] = true
+
+		findings = append(findings, models.Finding{
+			ID:          "twilio-api-key-sid",
+			Type:        models.FindingTypeSecret,
+			Fingerprint: models.SaltedFingerprint(sid, ctx.FingerprintSalt),
+			// Medium because the SID alone can't authenticate — but
+			// its presence almost always means the paired auth token
+			// is nearby, which IS the real secret.
+			Severity: "medium",
+			Title:    "Twilio API Key SID Detected",
+			Description: "A Twilio API Key SID identifies a Twilio API Key but is not itself a secret. " +
+				"The paired auth token (32 hex characters, typically named TWILIO_AUTH_TOKEN or stored " +
+				"next to the SID) is the actual credential — search the same file/environment for it " +
+				"and rotate it from the Twilio console.",
+			Message: fmt.Sprintf("A Twilio API Key SID was detected in %s.", ctx.FormatSource()),
+			Path:    ctx.Source,
+			Metadata: map[string]interface{}{
+				"detector_name": d.Name(),
+				"token_type":    "twilio-api-key-sid",
+			},
+		})
+	}
+	return findings
+}
+
+// Redact replaces Twilio SIDs in content with a redaction marker.
+func (d *TwilioKeyDetector) Redact(content string) (string, map[string]int) {
+	return ApplyRedactPatterns(content, d.redactPatterns)
+}

--- a/pkg/detector/twilio_key_test.go
+++ b/pkg/detector/twilio_key_test.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2026 boostsecurity.io
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package detector
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTwilioKeyDetector_Detect(t *testing.T) {
+	det := NewTwilioKeyDetector()
+
+	tests := []struct {
+		name      string
+		content   string
+		wantCount int
+	}{
+		{
+			name:      "API key SID (lowercase hex)",
+			content:   "TWILIO_API_KEY=SK0123456789abcdef0123456789abcdef",
+			wantCount: 1,
+		},
+		{
+			name:      "API key SID (uppercase hex)",
+			content:   "SK0123456789ABCDEF0123456789ABCDEF",
+			wantCount: 1,
+		},
+		{
+			name:      "Account SID is intentionally NOT matched",
+			content:   "TWILIO_ACCOUNT_SID=AC0123456789abcdef0123456789abcdef",
+			wantCount: 0,
+		},
+		{
+			name:      "SK with too few hex chars",
+			content:   "SK0123",
+			wantCount: 0,
+		},
+		{
+			name:      "SK with non-hex body",
+			content:   "SKzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz",
+			wantCount: 0,
+		},
+		{
+			name: "duplicate SID collapses",
+			content: `SK0123456789abcdef0123456789abcdef
+again SK0123456789abcdef0123456789abcdef`,
+			wantCount: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			findings := det.Detect(tt.content, testCtx("env:TWILIO_API_KEY"))
+			require.Len(t, findings, tt.wantCount)
+			if tt.wantCount > 0 {
+				f := findings[0]
+				assert.Equal(t, "twilio-api-key-sid", f.ID)
+				assert.Equal(t, "medium", f.Severity)
+				assert.Equal(t, "twilio-api-key-sid", f.Metadata["token_type"])
+			}
+		})
+	}
+}
+
+func TestTwilioKeyDetector_Redact(t *testing.T) {
+	det := NewTwilioKeyDetector()
+
+	out, counts := det.Redact("SID=SK0123456789abcdef0123456789abcdef")
+	assert.Equal(t, "SID=[REDACTED-twilio-api-key-sid]", out)
+	assert.Equal(t, 1, counts["REDACTED-twilio-api-key-sid"])
+}
+
+func TestTwilioKeyDetector_Name(t *testing.T) {
+	assert.Equal(t, "twilio-key", NewTwilioKeyDetector().Name())
+}


### PR DESCRIPTION
## Summary

Four new credential detectors covering common SaaS and infrastructure secrets that frequently leak from developer workstations.

- **database-connection-string** — postgres/postgresql/mysql/mariadb/mongodb(+srv)/redis(s)/amqp(s)/clickhouse/mssql URLs that embed a password in userinfo. URLs without a password (no userinfo, or username-only) are not flagged. Redaction preserves scheme/user/host so the surrounding file stays readable.
- **slack-token** — `xox[abprs]-` workspace tokens (bot / legacy-app / user / refresh / session) and `xapp-` Socket Mode app-level tokens. Metadata records `token_class` so callers can filter by class.
- **stripe-key** — `sk_` (secret), `rk_` (restricted), and `pk_` (publishable) keys across live/test modes. Severity scales: live secret/restricted → critical, test → high, publishable → low. Publishable keys are surfaced but intentionally not redacted (they're designed to ship in client-side code).
- **twilio-key** — API Key SIDs (`SK` + 32 hex). Severity medium because the SID itself isn't a secret — but its presence almost always means the paired auth token is nearby, which is the actual credential. Account SIDs (`AC…`) are deliberately not matched to keep noise down.

All four detectors are registered in both `cmd/bagel/scan.go` (detection) and `cmd/bagel/scrub.go` (redaction).

## Test plan

- [x] `go test ./pkg/detector/...` covers detection, redaction, and edge cases (too-short bodies, non-matching prefixes, duplicate collapse, scheme/severity variants) for each new detector
- [x] `golangci-lint run` passes (lint fixes in final commit)
- [x] Manual smoke: run `bagel scan` against a workstation with real `DATABASE_URL` / Slack / Stripe / Twilio env vars and confirm findings + severities match expectations