### PR TITLE
add iac credential probe; split file path from in-file location

### DIFF
--- a/cmd/bagel/scan.go
+++ b/cmd/bagel/scan.go
@@ -201,5 +201,10 @@ func initializeProbes(cfg *models.Config) []probe.Probe {
 		probes = append(probes, probe.NewDockerProbe(cfg.Probes.Docker, registry))
 	}
 
+	// Infrastructure-as-Code probe — Terraform + Helm credential discovery
+	if cfg.Probes.IaC.Enabled {
+		probes = append(probes, probe.NewIaCProbe(cfg.Probes.IaC, registry))
+	}
+
 	return probes
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -102,6 +102,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("probes.pypi.enabled", true)
 	v.SetDefault("probes.kube.enabled", true)
 	v.SetDefault("probes.docker.enabled", true)
+	v.SetDefault("probes.iac.enabled", true)
 	v.SetDefault("output.include_file_hashes", false)
 	v.SetDefault("output.include_file_content", false)
 
@@ -264,6 +265,32 @@ func setDefaults(v *viper.Viper) {
 			"Library/Application Support/pip/pip.conf",
 			// Windows
 			"AppData/Roaming/pip/pip.ini",
+		}, "type": "glob"},
+
+		// Terraform — credentials live in either path. The JSON form is
+		// authoritative for `terraform login`; the legacy HCL form is
+		// still common from manual setups.
+		{"name": "terraform_credentials", "patterns": []string{
+			".terraform.d/credentials.tfrc.json",
+			".terraformrc",
+		}, "type": "glob"},
+		// Terraform variable / state files. tfvars commonly hold cloud
+		// creds and DB passwords; local-backend state serializes resource
+		// outputs (including sensitive ones) as plaintext JSON.
+		{"name": "terraform_vars", "patterns": []string{
+			"*.tfvars",
+			"*.auto.tfvars",
+		}, "type": "glob"},
+		{"name": "terraform_state", "patterns": []string{
+			"terraform.tfstate",
+			"terraform.tfstate.backup",
+		}, "type": "glob"},
+
+		// Helm — username/password live under repositories[] in this file.
+		{"name": "helm_repositories", "patterns": []string{
+			".config/helm/repositories.yaml",
+			// macOS
+			"Library/Preferences/helm/repositories.yaml",
 		}, "type": "glob"},
 	})
 }

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -46,6 +46,7 @@ type ProbeConfig struct {
 	PyPI          ProbeSettings `yaml:"pypi" mapstructure:"pypi"`
 	Kube          ProbeSettings `yaml:"kube" mapstructure:"kube"`
 	Docker        ProbeSettings `yaml:"docker" mapstructure:"docker"`
+	IaC           ProbeSettings `yaml:"iac" mapstructure:"iac"`
 }
 
 // ProbeSettings contains settings for a specific probe

--- a/pkg/probe/docker.go
+++ b/pkg/probe/docker.go
@@ -149,10 +149,11 @@ func (p *DockerProbe) findingFromAuth(
 		return nil
 	}
 
-	// Bracket-and-quote notation so common registry keys
-	// (https://index.docker.io/v1/) — which contain dots, colons, and
-	// slashes — map back to auths[<key>].auth unambiguously.
-	source := fmt.Sprintf("file:%s#auths[%q].auth", path, host)
+	// Bracket-and-quote notation keeps it
+	// unambiguous when the registry host contains dots or slashes
+	// (https://index.docker.io/v1/ being the canonical example).
+	source := "file:" + path
+	location := fmt.Sprintf("auths[%q].auth", host)
 	primary := models.Finding{
 		ID:          "docker-registry-inline-auth",
 		Type:        models.FindingTypeSecret,
@@ -163,7 +164,7 @@ func (p *DockerProbe) findingFromAuth(
 		Description: "An inline base64(user:password) credential is stored in the container config. " +
 			"Configure a credential helper (credsStore / credHelpers) so credentials live in the OS keychain " +
 			"instead of on disk in cleartext.",
-		Message: fmt.Sprintf("Inline registry credential for %s in %s", host, path),
+		Message: fmt.Sprintf("Inline registry credential for %s in file:%s", host, path),
 		Path:    source,
 		Metadata: map[string]interface{}{
 			"runtime":          runtimeName,
@@ -171,6 +172,7 @@ func (p *DockerProbe) findingFromAuth(
 			"username":         username,
 			"has_password":     password != "",
 			"username_present": username != "",
+			"location":         location,
 		},
 	}
 	findings := make([]models.Finding, 0, 4)
@@ -191,6 +193,7 @@ func (p *DockerProbe) findingFromAuth(
 			}
 			f.Metadata["runtime"] = runtimeName
 			f.Metadata["registry_host"] = host
+			f.Metadata["location"] = location
 			findings = append(findings, f)
 		}
 	}
@@ -207,7 +210,8 @@ func (p *DockerProbe) findingFromIdentityToken(
 	host string,
 	token string,
 ) []models.Finding {
-	source := fmt.Sprintf("file:%s#auths[%q].identitytoken", path, host)
+	source := "file:" + path
+	location := fmt.Sprintf("auths[%q].identitytoken", host)
 	primary := models.Finding{
 		ID:          "docker-registry-inline-identity-token",
 		Type:        models.FindingTypeSecret,
@@ -217,11 +221,12 @@ func (p *DockerProbe) findingFromIdentityToken(
 		Title:       "Container Registry Identity Token Stored Inline",
 		Description: "A registry identity token is stored in the container config. Identity tokens are " +
 			"often long-lived OAuth refresh tokens; rotate the token and configure a credential helper.",
-		Message: fmt.Sprintf("Inline registry identity token for %s in %s", host, path),
+		Message: fmt.Sprintf("Inline registry identity token for %s in file:%s", host, path),
 		Path:    source,
 		Metadata: map[string]interface{}{
 			"runtime":       runtimeName,
 			"registry_host": host,
+			"location":      location,
 		},
 	}
 	findings := make([]models.Finding, 0, 4)
@@ -237,6 +242,7 @@ func (p *DockerProbe) findingFromIdentityToken(
 		}
 		f.Metadata["runtime"] = runtimeName
 		f.Metadata["registry_host"] = host
+		f.Metadata["location"] = location
 		findings = append(findings, f)
 	}
 	return findings

--- a/pkg/probe/iac.go
+++ b/pkg/probe/iac.go
@@ -264,7 +264,7 @@ func (p *IaCProbe) processHelmRepositories(ctx context.Context, path string) []m
 				"repo_url":         r.URL,
 				"username":         r.Username,
 				"username_present": r.Username != "",
-				"location":         fmt.Sprintf("repositories[%s]", r.Name),
+				"location":         fmt.Sprintf("repositories[%q]", r.Name),
 			},
 		})
 	}

--- a/pkg/probe/iac.go
+++ b/pkg/probe/iac.go
@@ -1,0 +1,289 @@
+// Copyright (C) 2026 boostsecurity.io
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package probe
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+
+	"github.com/boostsecurityio/bagel/pkg/detector"
+	"github.com/boostsecurityio/bagel/pkg/fileindex"
+	"github.com/boostsecurityio/bagel/pkg/models"
+	"github.com/rs/zerolog/log"
+	"gopkg.in/yaml.v3"
+)
+
+// defaultIaCMaxFileSize caps each per-file read. tfvars and tfstate
+// files can grow large in real projects but anything past this is
+// almost certainly accidental (e.g. checked-in plan output); keeping
+// the bound prevents unbounded YAML/JSON decode.
+const defaultIaCMaxFileSize = 4 * 1024 * 1024 // 4 MB
+
+// IaCProbe extracts credentials embedded in Infrastructure-as-Code
+// files: Terraform Cloud API tokens (credentials.tfrc.json /
+// .terraformrc), cloud creds and DB passwords baked into *.tfvars,
+// resource outputs serialized in local terraform.tfstate, and
+// username/password fields in Helm's repositories.yaml.
+//
+// Posture findings (file permissions, config completeness) are out of
+// scope — the probe targets credentials specifically.
+type IaCProbe struct {
+	enabled          bool
+	config           models.ProbeSettings
+	detectorRegistry *detector.Registry
+	fileIndex        *fileindex.FileIndex
+	maxFileSize      int64
+}
+
+// NewIaCProbe creates an IaC credential-extraction probe.
+// Accepts an optional flag "max_file_size" (int, bytes) overriding the
+// default 4 MB read cap.
+func NewIaCProbe(config models.ProbeSettings, registry *detector.Registry) *IaCProbe {
+	return &IaCProbe{
+		enabled:          config.Enabled,
+		config:           config,
+		detectorRegistry: registry,
+		maxFileSize:      readMaxFileSizeFlag(config.Flags, defaultIaCMaxFileSize),
+	}
+}
+
+// Name returns the probe name.
+func (p *IaCProbe) Name() string { return "iac" }
+
+// IsEnabled returns whether the probe is enabled.
+func (p *IaCProbe) IsEnabled() bool { return p.enabled }
+
+// SetFingerprintSalt sets the fingerprint salt on the detector registry.
+func (p *IaCProbe) SetFingerprintSalt(salt string) {
+	p.detectorRegistry.SetFingerprintSalt(salt)
+}
+
+// SetFileIndex sets the file index for this probe.
+func (p *IaCProbe) SetFileIndex(index *fileindex.FileIndex) {
+	p.fileIndex = index
+}
+
+// Execute walks every IaC file pattern and dispatches per shape.
+func (p *IaCProbe) Execute(ctx context.Context) ([]models.Finding, error) {
+	if p.fileIndex == nil {
+		log.Ctx(ctx).Warn().
+			Str("probe", p.Name()).
+			Msg("File index not available, skipping IaC probe")
+		return nil, nil
+	}
+
+	var findings []models.Finding
+
+	for _, path := range p.fileIndex.Get("terraform_credentials") {
+		findings = append(findings, p.processTerraformCredentials(ctx, path)...)
+	}
+	// tfvars / tfstate / helm files all benefit from the same
+	// line-scan-then-fall-through-to-registry approach. Existing
+	// detectors (cloud creds, JWT, generic API key, DB connection
+	// strings, slack/stripe/twilio) cover the secret shapes.
+	for _, path := range p.fileIndex.Get("terraform_vars") {
+		findings = append(findings, p.scanThroughRegistry(ctx, path)...)
+	}
+	for _, path := range p.fileIndex.Get("terraform_state") {
+		findings = append(findings, p.scanThroughRegistry(ctx, path)...)
+	}
+	for _, path := range p.fileIndex.Get("helm_repositories") {
+		findings = append(findings, p.processHelmRepositories(ctx, path)...)
+	}
+
+	return findings, nil
+}
+
+// readBounded reads a file but caps it at maxFileSize. Returns nil if
+// the file is missing or oversized; logs at debug in both cases.
+func (p *IaCProbe) readBounded(ctx context.Context, path string) []byte {
+	info, err := os.Stat(path)
+	if err != nil {
+		log.Ctx(ctx).Debug().Err(err).Str("file", path).Msg("Cannot stat IaC file")
+		return nil
+	}
+	if info.Size() > p.maxFileSize {
+		log.Ctx(ctx).Debug().
+			Str("file", path).
+			Int64("size_bytes", info.Size()).
+			Int64("max_size_bytes", p.maxFileSize).
+			Msg("Skipping oversized IaC file")
+		return nil
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		log.Ctx(ctx).Debug().Err(err).Str("file", path).Msg("Cannot read IaC file")
+		return nil
+	}
+	return content
+}
+
+// scanThroughRegistry feeds every line of a file to the detector
+// registry. Used for free-form IaC content (tfvars, tfstate) where
+// secrets show up as embedded strings caught by the existing
+// detectors.
+func (p *IaCProbe) scanThroughRegistry(ctx context.Context, path string) []models.Finding {
+	content := p.readBounded(ctx, path)
+	if content == nil {
+		return nil
+	}
+	return scanReaderLines(ctx, "file:"+path, bytes.NewReader(content), p.Name(), p.detectorRegistry, int(p.maxFileSize)+1)
+}
+
+// terraformCredentialsJSON is the schema of credentials.tfrc.json.
+// `terraform login` writes this; the legacy .terraformrc HCL form is
+// handled with a regex below.
+type terraformCredentialsJSON struct {
+	Credentials map[string]struct {
+		Token string `json:"token"`
+	} `json:"credentials"`
+}
+
+// terraformrcCredsRegex matches the HCL form:
+//
+//	credentials "app.terraform.io" {
+//	  token = "atlas.v1.…"
+//	}
+//
+// It tolerates flexible whitespace and either single or double quotes
+// around the token, which terraform CLI itself accepts.
+var terraformrcCredsRegex = regexp.MustCompile(
+	`credentials\s+["']([^"']+)["']\s*\{[^}]*?token\s*=\s*["']([^"']+)["']`,
+)
+
+// processTerraformCredentials emits a finding per Terraform Cloud /
+// Enterprise host with a stored API token. JSON is preferred; HCL is a
+// best-effort fallback.
+func (p *IaCProbe) processTerraformCredentials(ctx context.Context, path string) []models.Finding {
+	content := p.readBounded(ctx, path)
+	if content == nil {
+		return nil
+	}
+
+	// JSON form first — it's authoritative.
+	var doc terraformCredentialsJSON
+	if err := json.Unmarshal(content, &doc); err == nil && len(doc.Credentials) > 0 {
+		findings := make([]models.Finding, 0, len(doc.Credentials))
+		for host, entry := range doc.Credentials {
+			if entry.Token == "" {
+				continue
+			}
+			findings = append(findings, p.terraformCredentialFinding(path, host, entry.Token, "json"))
+		}
+		return findings
+	}
+
+	// HCL fallback — terraform CLI itself accepts both formats.
+	matches := terraformrcCredsRegex.FindAllStringSubmatch(string(content), -1)
+	findings := make([]models.Finding, 0, len(matches))
+	for _, m := range matches {
+		host, token := m[1], m[2]
+		if token == "" {
+			continue
+		}
+		findings = append(findings, p.terraformCredentialFinding(path, host, token, "hcl"))
+	}
+	return findings
+}
+
+func (p *IaCProbe) terraformCredentialFinding(path, host, token, format string) models.Finding {
+	return models.Finding{
+		ID:          "terraform-cloud-credential",
+		Type:        models.FindingTypeSecret,
+		Fingerprint: models.FingerprintFromFields("terraform-cloud-credential", path, host),
+		Probe:       p.Name(),
+		Severity:    "critical",
+		Title:       "Terraform Cloud/Enterprise API Token Stored Locally",
+		Description: "A Terraform Cloud or Enterprise API token is stored in plaintext. " +
+			"These tokens grant full API access to workspaces, state, and runs. Revoke " +
+			"and re-create the token from the Terraform Cloud UI if the host is shared.",
+		Message: fmt.Sprintf("Terraform credential for %s in file:%s", host, path),
+		// Path stays a plain `file:<absolute path>` so terminals'
+		// open-file affordances work; the in-file location goes to
+		// metadata where structured consumers can read it.
+		Path: "file:" + path,
+		Metadata: map[string]interface{}{
+			"host":           host,
+			"file_format":    format,
+			"token_prefix":   tokenPrefix(token),
+			"token_fragment": maskFragment(token),
+			"location":       fmt.Sprintf("credentials[%q].token", host),
+		},
+	}
+}
+
+// helmRepositoriesDoc is the minimum subset of repositories.yaml needed
+// to reach username/password fields. Helm has many other fields that
+// aren't credentials.
+type helmRepositoriesDoc struct {
+	Repositories []struct {
+		Name     string `yaml:"name"`
+		URL      string `yaml:"url"`
+		Username string `yaml:"username"`
+		Password string `yaml:"password"`
+	} `yaml:"repositories"`
+}
+
+// processHelmRepositories emits a finding per Helm repo entry that has
+// a non-empty password. Plain `name + url` entries (the public-chart
+// case) are silently skipped.
+func (p *IaCProbe) processHelmRepositories(ctx context.Context, path string) []models.Finding {
+	content := p.readBounded(ctx, path)
+	if content == nil {
+		return nil
+	}
+	var doc helmRepositoriesDoc
+	if err := yaml.Unmarshal(content, &doc); err != nil {
+		log.Ctx(ctx).Debug().Err(err).Str("file", path).Msg("Cannot parse Helm repositories.yaml")
+		return nil
+	}
+	findings := make([]models.Finding, 0, len(doc.Repositories))
+	for _, r := range doc.Repositories {
+		if r.Password == "" {
+			continue
+		}
+		findings = append(findings, models.Finding{
+			ID:          "helm-repository-credential",
+			Type:        models.FindingTypeSecret,
+			Fingerprint: models.FingerprintFromFields("helm-repository-credential", path, r.Name),
+			Probe:       p.Name(),
+			Severity:    "critical",
+			Title:       "Helm Repository Credential Stored Inline",
+			Description: "A Helm repository entry stores a password in plaintext. " +
+				"Configure a credentials helper or pass --username/--password at install time " +
+				"so the secret doesn't sit on disk.",
+			Message: fmt.Sprintf("Helm credential for repo %q (%s) in file:%s", r.Name, r.URL, path),
+			Path:    "file:" + path,
+			Metadata: map[string]interface{}{
+				"repo_name":        r.Name,
+				"repo_url":         r.URL,
+				"username":         r.Username,
+				"username_present": r.Username != "",
+				"location":         fmt.Sprintf("repositories[%s]", r.Name),
+			},
+		})
+	}
+	return findings
+}
+
+// tokenPrefix returns the first <= 8 characters of a token. Useful for
+// recognizing the token family (atlas.v1, hvs., etc.) without leaking
+// the secret value.
+func tokenPrefix(token string) string {
+	if len(token) <= 8 {
+		return token
+	}
+	return token[:8]
+}
+
+// maskFragment returns a short masked indicator of a token's length —
+// e.g. "atlas.v1.…(64)" — so users can confirm which token is meant
+// without surfacing the full value.
+func maskFragment(token string) string {
+	return fmt.Sprintf("%s…(%d)", tokenPrefix(token), len(token))
+}

--- a/pkg/probe/iac_test.go
+++ b/pkg/probe/iac_test.go
@@ -1,0 +1,243 @@
+// Copyright (C) 2026 boostsecurity.io
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package probe
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/boostsecurityio/bagel/pkg/detector"
+	"github.com/boostsecurityio/bagel/pkg/fileindex"
+	"github.com/boostsecurityio/bagel/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newIaCRegistry() *detector.Registry {
+	reg := detector.NewRegistry()
+	// The registry the probe shares with the rest of the scan — the
+	// IaC line-scan paths rely on existing detectors firing on
+	// embedded values.
+	reg.Register(detector.NewGitHubPATDetector())
+	reg.Register(detector.NewCloudCredentialsDetector())
+	reg.Register(detector.NewJWTDetector())
+	reg.Register(detector.NewDatabaseConnectionDetector())
+	reg.Register(detector.NewGenericAPIKeyDetector())
+	return reg
+}
+
+func TestIaCProbe_TerraformCredentialsJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "credentials.tfrc.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{
+  "credentials": {
+    "app.terraform.io": {"token": "atlas.v1.aaaabbbbccccddddeeeeffffgggghhhh"},
+    "tfe.example.com":  {"token": "atlas.v1.shouldnotmatterforthetest"}
+  }
+}`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("terraform_credentials", path)
+
+	probe := NewIaCProbe(models.ProbeSettings{Enabled: true}, newIaCRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	require.Len(t, findings, 2)
+
+	hosts := make(map[string]bool)
+	for _, f := range findings {
+		assert.Equal(t, "terraform-cloud-credential", f.ID)
+		assert.Equal(t, "critical", f.Severity)
+		assert.Equal(t, "json", f.Metadata["file_format"])
+		assert.Equal(t, "atlas.v1", f.Metadata["token_prefix"])
+		hosts[f.Metadata["host"].(string)] = true
+	}
+	assert.True(t, hosts["app.terraform.io"])
+	assert.True(t, hosts["tfe.example.com"])
+}
+
+func TestIaCProbe_TerraformrcHCLFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, ".terraformrc")
+	require.NoError(t, os.WriteFile(path, []byte(`
+credentials "app.terraform.io" {
+  token = "atlas.v1.legacyhclformat0123456789abcdef"
+}
+`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("terraform_credentials", path)
+
+	probe := NewIaCProbe(models.ProbeSettings{Enabled: true}, newIaCRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	assert.Equal(t, "terraform-cloud-credential", findings[0].ID)
+	assert.Equal(t, "hcl", findings[0].Metadata["file_format"])
+	assert.Equal(t, "app.terraform.io", findings[0].Metadata["host"])
+}
+
+func TestIaCProbe_TfvarsLineScanCatchesCloudCreds(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "prod.tfvars")
+	// Embed an AWS access key — the existing CloudCredentials detector
+	// should fire on this through the line-scan.
+	require.NoError(t, os.WriteFile(path, []byte(`
+aws_region            = "us-east-1"
+aws_access_key_id     = "AKIAIOSFODNN7EXAMPLE"
+db_password           = "supersecret"
+`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("terraform_vars", path)
+
+	probe := NewIaCProbe(models.ProbeSettings{Enabled: true}, newIaCRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+
+	awsFound := false
+	for _, f := range findings {
+		if f.ID == "cloud-credential-aws-access-key-id" {
+			awsFound = true
+			break
+		}
+	}
+	assert.True(t, awsFound, "expected AWS access key finding from tfvars line scan")
+}
+
+func TestIaCProbe_TfstateLineScanCatchesGitHubPAT(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "terraform.tfstate")
+	pat := "ghp_" + "0123456789abcdefghijABCDEFGHIJ012345"
+	require.NoError(t, os.WriteFile(path, []byte(`{
+  "outputs": {
+    "deploy_token": {"value": "`+pat+`"}
+  }
+}`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("terraform_state", path)
+
+	probe := NewIaCProbe(models.ProbeSettings{Enabled: true}, newIaCRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+
+	found := false
+	for _, f := range findings {
+		if cls, _ := f.Metadata["token_type"].(string); cls == "classic-pat" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected GitHub PAT finding from tfstate line scan")
+}
+
+func TestIaCProbe_HelmRepositoriesWithPassword(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "repositories.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+apiVersion: ""
+repositories:
+- name: bitnami
+  url: https://charts.bitnami.com/bitnami
+- name: private-charts
+  url: https://charts.example.com
+  username: deploy-bot
+  password: hunter2-supersecret
+- name: another-public
+  url: https://other.example.com
+`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("helm_repositories", path)
+
+	probe := NewIaCProbe(models.ProbeSettings{Enabled: true}, newIaCRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	f := findings[0]
+	assert.Equal(t, "helm-repository-credential", f.ID)
+	assert.Equal(t, "critical", f.Severity)
+	assert.Equal(t, "private-charts", f.Metadata["repo_name"])
+	assert.Equal(t, "deploy-bot", f.Metadata["username"])
+	assert.Equal(t, true, f.Metadata["username_present"])
+}
+
+func TestIaCProbe_HelmRepositoriesNoPasswordIgnored(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "repositories.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+repositories:
+- name: bitnami
+  url: https://charts.bitnami.com/bitnami
+`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("helm_repositories", path)
+
+	probe := NewIaCProbe(models.ProbeSettings{Enabled: true}, newIaCRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, findings, "repos without passwords must not emit findings")
+}
+
+func TestIaCProbe_SkipsOversized(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "prod.tfvars")
+	require.NoError(t, os.WriteFile(path, make([]byte, 2048), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("terraform_vars", path)
+
+	probe := NewIaCProbe(models.ProbeSettings{
+		Enabled: true,
+		Flags:   map[string]interface{}{"max_file_size": 1024},
+	}, newIaCRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}
+
+func TestIaCProbe_MalformedJSONFallsBackToHCL(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, ".terraformrc")
+	// Not JSON; the HCL regex should still produce a finding.
+	require.NoError(t, os.WriteFile(path, []byte(`credentials "tfe.local" {
+  token = "atlas.v1.0123456789abcdef0123456789abcdef"
+}`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("terraform_credentials", path)
+
+	probe := NewIaCProbe(models.ProbeSettings{Enabled: true}, newIaCRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+	assert.Equal(t, "hcl", findings[0].Metadata["file_format"])
+}
+
+func TestIaCProbe_NoFileIndexReturnsNothing(t *testing.T) {
+	probe := NewIaCProbe(models.ProbeSettings{Enabled: true}, newIaCRegistry())
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}

--- a/pkg/probe/kube.go
+++ b/pkg/probe/kube.go
@@ -226,7 +226,8 @@ func (p *KubeProbe) scanEncoded(
 		return nil
 	}
 
-	source := fmt.Sprintf("file:%s#users[%d].user.%s", path, userIdx, field)
+	source := "file:" + path
+	location := fmt.Sprintf("users[%d].user.%s", userIdx, field)
 	detCtx := models.NewDetectionContext(models.NewDetectionContextInput{
 		Source:    source,
 		ProbeName: p.Name(),
@@ -242,6 +243,7 @@ func (p *KubeProbe) scanEncoded(
 		found[i].Metadata["kubeconfig_path"] = path
 		found[i].Metadata["kubeconfig_user"] = userName
 		found[i].Metadata["kubeconfig_field"] = field
+		found[i].Metadata["location"] = location
 	}
 	return found
 }


### PR DESCRIPTION
## Summary

New Infrastructure-as-Code probe plus a small metadata refactor across the docker/kube/iac probes so `Path` stays a clean `file:<absolute path>` and the in-file location (which YAML node, which JSON key) moves to a `location` metadata field. Terminal/IDE open-file affordances now work on the `Path` field; structured consumers still get the precise location separately.

### New probe — `iac` (`pkg/probe/iac.go`)

Targets credentials, not posture. Covers four file shapes:

- **Terraform Cloud / Enterprise tokens** — `credentials.tfrc.json` (authoritative, written by `terraform login`) and the legacy HCL `.terraformrc`. JSON is parsed first; HCL is a best-effort regex fallback that tolerates flexible whitespace and either quote style (matching what the Terraform CLI itself accepts). One finding per host; metadata records `host`, `file_format`, `token_prefix`, `token_fragment` (length-indicator only, never the full token), and `location`.
- **Terraform variables** — `*.tfvars` / `*.auto.tfvars` get a line-scan through the shared detector registry, so the existing cloud-credential, DB-connection-string, JWT, GitHub PAT, etc. detectors fire on values like `aws_access_key_id = \"AKIA…\"` or `db_password = \"postgres://…\"`.
- **Terraform state** — `terraform.tfstate` / `terraform.tfstate.backup` get the same line-scan treatment. Local-backend state serializes resource outputs as plaintext JSON, so any sensitive output value (deploy tokens, etc.) flows through the registry.
- **Helm repositories** — `repositories.yaml` (XDG + macOS paths). Emits a finding per repo entry with a non-empty `password`; public-chart entries (`name + url` only) are silently skipped.

Bounded reads (default 4 MB, overridable via `max_file_size` flag) keep YAML/JSON decode safe on accidentally-large files (checked-in plan outputs, etc.).

### Refactor — `Path` vs `location` (`pkg/probe/docker.go`, `pkg/probe/kube.go`)

Previously the in-file location was glued onto `Path` as a URL fragment (`file:<path>#auths[\"…\"].auth`). That breaks terminal/IDE click-to-open. Now:

- `Path` is just `file:<absolute path>`.
- `Metadata.location` holds the structured pointer (`auths[\"ghcr.io\"].auth`, `users[0].user.client-key-data`, `credentials[\"app.terraform.io\"].token`, `repositories[\"private-charts\"]`).
- `Message` also includes `file:<path>` so the human-readable output still shows it.

### Config (`pkg/config/config.go`, `pkg/models/config.go`)

New file-index patterns: `terraform_credentials`, `terraform_vars`, `terraform_state`, `helm_repositories`. New probe config `probes.iac.enabled` (defaults on).

## Test plan

- [x] `go test ./pkg/probe/...` covers Terraform JSON credentials, HCL fallback, tfvars line-scan firing AWS detector, tfstate line-scan firing GitHub PAT detector, Helm repo with password, Helm repo without password (skipped), oversized-file skip, no-file-index, and the JSON-to-HCL fallback path
- [x] `golangci-lint run` and `go vet ./...` pass
- [x] Copilot autofix applied (`%q` on Helm `location` to keep bracket notation safe when repo names contain special characters)
- [x] Manual smoke: run `bagel scan` against a workstation with `~/.terraform.d/credentials.tfrc.json` + checked-out Terraform module + Helm install, and confirm findings look right