### PR TITLE
add ai_mcp + ai_context probes; cover more ai chat surfaces

### DIFF
--- a/cmd/bagel/scan.go
+++ b/cmd/bagel/scan.go
@@ -206,5 +206,16 @@ func initializeProbes(cfg *models.Config) []probe.Probe {
 		probes = append(probes, probe.NewIaCProbe(cfg.Probes.IaC, registry))
 	}
 
+	// AI MCP probe — credentials in MCP server configs (scan-only;
+	// scrub would break agents by replacing real tokens with markers).
+	if cfg.Probes.AIMCP.Enabled {
+		probes = append(probes, probe.NewMCPProbe(cfg.Probes.AIMCP, registry))
+	}
+
+	// AI context/memory probe — CLAUDE.md / AGENTS.md scanning.
+	if cfg.Probes.AIContext.Enabled {
+		probes = append(probes, probe.NewContextProbe(cfg.Probes.AIContext, registry))
+	}
+
 	return probes
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -273,6 +273,25 @@ func setDefaults(v *viper.Viper) {
 			"AGENTS.md",
 		}, "type": "glob"},
 
+		// Claude Code user-level customization. Commands, agents, and
+		// skills are user-authored Markdown that Claude loads as
+		// context — secrets in the prompt body get sent to the model
+		// on every invocation.
+		{"name": "claude_commands", "patterns": []string{".claude/commands/*.md"}, "type": "glob"},
+		{"name": "claude_agents", "patterns": []string{".claude/agents/*.md"}, "type": "glob"},
+		// Skills usually have SKILL.md at the skill root plus optional
+		// sibling .md docs; the glob catches both shapes.
+		{"name": "claude_skills", "patterns": []string{".claude/skills/*/*.md"}, "type": "glob"},
+		// Cross-agent skill store (a number of plugins symlink into
+		// ~/.agents/skills/). Worth scanning so the underlying files
+		// surface even when symlinks aren't being followed.
+		{"name": "agents_skills", "patterns": []string{".agents/skills/*/*.md"}, "type": "glob"},
+
+		// Codex CLI context/memory.
+		{"name": "codex_instructions", "patterns": []string{".codex/instructions.md"}, "type": "glob"},
+		{"name": "codex_memories", "patterns": []string{".codex/memories/*"}, "type": "glob"},
+		{"name": "codex_skills", "patterns": []string{".codex/skills/*/*.md"}, "type": "glob"},
+
 		// WireGuard (user-level configs; system paths are checked directly by the probe)
 		{"name": "wireguard_config", "patterns": []string{".config/wireguard/*.conf"}, "type": "glob"},
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -103,6 +103,8 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("probes.kube.enabled", true)
 	v.SetDefault("probes.docker.enabled", true)
 	v.SetDefault("probes.iac.enabled", true)
+	v.SetDefault("probes.ai_mcp.enabled", true)
+	v.SetDefault("probes.ai_context.enabled", true)
 	v.SetDefault("output.include_file_hashes", false)
 	v.SetDefault("output.include_file_content", false)
 
@@ -249,6 +251,27 @@ func setDefaults(v *viper.Viper) {
 		{"name": "codex_chats", "patterns": []string{".codex/sessions/*/*/*/rollout-*.jsonl"}, "type": "glob"},
 		{"name": "claude_chats", "patterns": []string{".claude/projects/*/*.jsonl"}, "type": "glob"},
 		{"name": "opencode_chats", "patterns": []string{".local/share/opencode/storage/part/msg_*/prt_*.json"}, "type": "glob"},
+
+		// AI agent MCP server configs. mcpServers blocks carry the env
+		// map that holds API tokens for third-party services (GitHub
+		// PATs, Slack tokens, etc.). claude.json is the application
+		// state file; settings.{,local.}json may carry mcpServers too;
+		// .mcp.json is a project-level MCP-only file.
+		{"name": "claude_app_state", "patterns": []string{".claude/claude.json"}, "type": "glob"},
+		{"name": "claude_settings", "patterns": []string{
+			".claude/settings.json",
+			".claude/settings.local.json",
+		}, "type": "glob"},
+		{"name": "mcp_project_config", "patterns": []string{".mcp.json"}, "type": "glob"},
+
+		// AI agent context/memory files — pasted secrets get baked
+		// into these by users. Basename match: catch them anywhere
+		// under home (per-repo CLAUDE.md, global ~/.claude/CLAUDE.md,
+		// codex/opencode AGENTS.md, etc.).
+		{"name": "ai_memory_md", "patterns": []string{
+			"CLAUDE.md",
+			"AGENTS.md",
+		}, "type": "glob"},
 
 		// WireGuard (user-level configs; system paths are checked directly by the probe)
 		{"name": "wireguard_config", "patterns": []string{".config/wireguard/*.conf"}, "type": "glob"},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -252,6 +252,18 @@ func setDefaults(v *viper.Viper) {
 		{"name": "claude_chats", "patterns": []string{".claude/projects/*/*.jsonl"}, "type": "glob"},
 		{"name": "opencode_chats", "patterns": []string{".local/share/opencode/storage/part/msg_*/prt_*.json"}, "type": "glob"},
 
+		// Additional AI agent history / paste / env surfaces beyond
+		// session rollouts. Users routinely paste tokens into prompts;
+		// the paste-cache is literally a record of those pastes. REPL
+		// history files capture every prompt the user submitted at the
+		// top level (separate from per-session rollouts).
+		{"name": "claude_repl_history", "patterns": []string{".claude/history.jsonl"}, "type": "glob"},
+		{"name": "claude_paste_cache", "patterns": []string{".claude/paste-cache/*"}, "type": "glob"},
+		{"name": "claude_session_env", "patterns": []string{".claude/session-env/*"}, "type": "glob"},
+		{"name": "codex_repl_history", "patterns": []string{".codex/history.jsonl"}, "type": "glob"},
+		{"name": "opencode_session_info", "patterns": []string{".local/share/opencode/storage/session/info/*.json"}, "type": "glob"},
+		{"name": "opencode_session_message", "patterns": []string{".local/share/opencode/storage/session/message/*/*.json"}, "type": "glob"},
+
 		// AI agent MCP server configs. mcpServers blocks carry the env
 		// map that holds API tokens for third-party services (GitHub
 		// PATs, Slack tokens, etc.). claude.json is the application

--- a/pkg/fileindex/fileindex.go
+++ b/pkg/fileindex/fileindex.go
@@ -153,14 +153,29 @@ func compilePattern(kind PatternType, pat string) patternMatcher {
 		// `.claude/commands/*.md` catch both `~/.claude/commands/foo.md`
 		// (home-level) and `~/projects/repo/.claude/commands/foo.md`
 		// (project-level) without forcing callers to enumerate depths.
-		needed := strings.Count(normalized, string(os.PathSeparator)) + 1
+		//
+		// Implemented as a reverse byte scan so the suffix is a slice
+		// of relPath — no allocation per call, which matters because
+		// BuildIndex invokes every matcher against every walked file.
+		sep := byte(os.PathSeparator)
+		seps := strings.Count(normalized, string(rune(sep)))
 		return func(_, relPath string) bool {
-			parts := strings.Split(relPath, string(os.PathSeparator))
-			if len(parts) < needed {
+			start := 0
+			seen := 0
+			for i := len(relPath) - 1; i >= 0; i-- {
+				if relPath[i] != sep {
+					continue
+				}
+				seen++
+				if seen > seps {
+					start = i + 1
+					break
+				}
+			}
+			if seen < seps {
 				return false
 			}
-			suffix := strings.Join(parts[len(parts)-needed:], string(os.PathSeparator))
-			matched, _ := filepath.Match(normalized, suffix)
+			matched, _ := filepath.Match(normalized, relPath[start:])
 			return matched
 		}
 	default:

--- a/pkg/fileindex/fileindex.go
+++ b/pkg/fileindex/fileindex.go
@@ -109,8 +109,12 @@ func compilePatterns(patterns []Pattern) []compiledPattern {
 	return out
 }
 
-// compilePattern classifies a raw entry into its minimum-cost matcher: exact,
-// basename glob, literal path (suffix match at any depth), or anchored path glob.
+// compilePattern classifies a raw entry into its minimum-cost matcher:
+// exact, basename glob (matches anywhere), literal path (suffix match
+// at any depth), or wildcard path glob (suffix match against the last
+// N+1 segments of the relPath, where N = number of slashes in the
+// pattern). All three glob shapes match anywhere under the base dir;
+// users who need anchoring can use PatternTypeExact instead.
 func compilePattern(kind PatternType, pat string) patternMatcher {
 	switch kind {
 	case PatternTypeExact:
@@ -142,8 +146,21 @@ func compilePattern(kind PatternType, pat string) patternMatcher {
 		if _, err := filepath.Match(normalized, ""); err != nil {
 			return func(string, string) bool { return false }
 		}
+		// Suffix-match: pattern matches the last N+1 segments of the
+		// relPath (N = slash count in pattern). Same shape as the
+		// literal-path branch above, just with filepath.Match doing the
+		// per-segment comparison. This is what lets a pattern like
+		// `.claude/commands/*.md` catch both `~/.claude/commands/foo.md`
+		// (home-level) and `~/projects/repo/.claude/commands/foo.md`
+		// (project-level) without forcing callers to enumerate depths.
+		needed := strings.Count(normalized, string(os.PathSeparator)) + 1
 		return func(_, relPath string) bool {
-			matched, _ := filepath.Match(normalized, relPath)
+			parts := strings.Split(relPath, string(os.PathSeparator))
+			if len(parts) < needed {
+				return false
+			}
+			suffix := strings.Join(parts[len(parts)-needed:], string(os.PathSeparator))
+			matched, _ := filepath.Match(normalized, suffix)
 			return matched
 		}
 	default:

--- a/pkg/fileindex/fileindex_test.go
+++ b/pkg/fileindex/fileindex_test.go
@@ -354,6 +354,48 @@ func TestPatternMatching_GlobPatterns(t *testing.T) {
 	assert.Len(t, sshKeys, 3) // Should match id_rsa, id_ed25519, id_ecdsa
 }
 
+// TestPatternMatching_WildcardSuffix locks in the behavior that
+// wildcard-plus-slash patterns match anywhere under the base dir, not
+// just at the root. This is what lets a pattern like
+// `.claude/commands/*.md` catch project-level agent files without
+// users having to enumerate every project depth.
+func TestPatternMatching_WildcardSuffix(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	testFiles := []string{
+		// Home-root level — must still match.
+		".claude/commands/deploy.md",
+		// Project level at varying depths — must also match.
+		"projects/repo-a/.claude/commands/build.md",
+		"work/team/projects/repo-b/.claude/commands/lint.md",
+		// Wrong segment count — must NOT match (* doesn't traverse /).
+		".claude/commands/sub/nested.md",
+		// Wrong leaf extension — must NOT match.
+		".claude/commands/notes.txt",
+	}
+
+	for _, file := range testFiles {
+		fullPath := filepath.Join(tmpDir, file)
+		require.NoError(t, os.MkdirAll(filepath.Dir(fullPath), 0755))
+		require.NoError(t, os.WriteFile(fullPath, []byte("x"), 0644))
+	}
+
+	patterns := []Pattern{{
+		Name:     "claude_commands",
+		Patterns: []string{".claude/commands/*.md"},
+		Type:     PatternTypeGlob,
+	}}
+
+	index, err := BuildIndex(context.Background(), BuildIndexInput{
+		BaseDirs: []string{tmpDir},
+		Patterns: patterns,
+	})
+	require.NoError(t, err)
+
+	matches := index.Get("claude_commands")
+	assert.Len(t, matches, 3, "expected the three .md command files at varying depths to match, got: %v", matches)
+}
+
 func TestPatternMatching_ExactMatch(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -47,6 +47,8 @@ type ProbeConfig struct {
 	Kube          ProbeSettings `yaml:"kube" mapstructure:"kube"`
 	Docker        ProbeSettings `yaml:"docker" mapstructure:"docker"`
 	IaC           ProbeSettings `yaml:"iac" mapstructure:"iac"`
+	AIMCP         ProbeSettings `yaml:"ai_mcp" mapstructure:"ai_mcp"`
+	AIContext     ProbeSettings `yaml:"ai_context" mapstructure:"ai_context"`
 }
 
 // ProbeSettings contains settings for a specific probe

--- a/pkg/probe/ai_chats.go
+++ b/pkg/probe/ai_chats.go
@@ -17,13 +17,29 @@ import (
 const defaultAIChatsMaxFileSize = 1 * 1024 * 1024 // 1MB
 
 // aiChatsPatterns lists the FileIndex pattern names whose matches hold AI
-// CLI conversation history. These are append-only logs: scrubbing them is
-// safe because tools don't read them back as state.
+// CLI conversation history, REPL input, paste cache, and per-session env
+// snapshots. All are append-only/replaceable surfaces: scrubbing them is
+// safe because tools don't read them back as authoritative state — at
+// worst a replay surfaces `[REDACTED-X]` instead of the original secret,
+// which is the desired outcome.
 var aiChatsPatterns = []string{
 	"gemini_chats",
 	"codex_chats",
 	"claude_chats",
 	"opencode_chats",
+
+	// REPL input + paste + per-session env (Claude Code).
+	"claude_repl_history",
+	"claude_paste_cache",
+	"claude_session_env",
+
+	// Codex top-level REPL history (distinct from sessions/rollouts).
+	"codex_repl_history",
+
+	// OpenCode session metadata + message storage (siblings to the
+	// existing opencode_chats `part/` files).
+	"opencode_session_info",
+	"opencode_session_message",
 }
 
 // AIChatsProbe scans AI CLI conversation history files (jsonl, chat json).

--- a/pkg/probe/ai_chats_test.go
+++ b/pkg/probe/ai_chats_test.go
@@ -138,3 +138,118 @@ func TestAIChatsProbe_CustomMaxFileSizeFlag(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, findings, "file exceeding custom max_file_size must be skipped")
 }
+
+// Chunk C: REPL history / paste / session-env / OpenCode session
+// patterns all route through ai_chats. One test per pattern bucket
+// gives us a regression net against the slice drifting out of sync
+// with the file index patterns.
+
+func TestAIChatsProbe_DetectsClaudeREPLHistory(t *testing.T) {
+	tmpDir := t.TempDir()
+	pat := "ghp_" + "0123456789abcdefghijABCDEFGHIJ012345"
+	path := filepath.Join(tmpDir, "history.jsonl")
+	require.NoError(t, os.WriteFile(path,
+		[]byte(`{"display":"please use `+pat+` for the API","timestamp":1759181670089}`),
+		0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("claude_repl_history", path)
+
+	registry := detector.NewRegistry()
+	registry.Register(detector.NewGitHubPATDetector())
+
+	probe := NewAIChatsProbe(models.ProbeSettings{Enabled: true}, registry)
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, findings)
+	assert.Equal(t, "github-token-classic-pat", findings[0].ID)
+}
+
+func TestAIChatsProbe_DetectsClaudePasteCache(t *testing.T) {
+	tmpDir := t.TempDir()
+	pat := "ghp_" + "0123456789abcdefghijABCDEFGHIJ012345"
+	path := filepath.Join(tmpDir, "0ec4da028dc1b738.txt")
+	require.NoError(t, os.WriteFile(path, []byte(pat), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("claude_paste_cache", path)
+
+	registry := detector.NewRegistry()
+	registry.Register(detector.NewGitHubPATDetector())
+
+	probe := NewAIChatsProbe(models.ProbeSettings{Enabled: true}, registry)
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, findings)
+	assert.Equal(t, "github-token-classic-pat", findings[0].ID)
+}
+
+func TestAIChatsProbe_DetectsClaudeSessionEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	pat := "ghp_" + "0123456789abcdefghijABCDEFGHIJ012345"
+	path := filepath.Join(tmpDir, "12ffc74a-c66f-4ab1-a851-16b70c04bca7")
+	require.NoError(t, os.WriteFile(path, []byte("GITHUB_TOKEN="+pat+"\n"), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("claude_session_env", path)
+
+	registry := detector.NewRegistry()
+	registry.Register(detector.NewGitHubPATDetector())
+
+	probe := NewAIChatsProbe(models.ProbeSettings{Enabled: true}, registry)
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, findings)
+}
+
+func TestAIChatsProbe_DetectsCodexREPLHistory(t *testing.T) {
+	tmpDir := t.TempDir()
+	pat := "ghp_" + "0123456789abcdefghijABCDEFGHIJ012345"
+	path := filepath.Join(tmpDir, "history.jsonl")
+	require.NoError(t, os.WriteFile(path, []byte(`{"prompt":"`+pat+`"}`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("codex_repl_history", path)
+
+	registry := detector.NewRegistry()
+	registry.Register(detector.NewGitHubPATDetector())
+
+	probe := NewAIChatsProbe(models.ProbeSettings{Enabled: true}, registry)
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, findings)
+}
+
+func TestAIChatsProbe_DetectsOpenCodeSessionInfoAndMessage(t *testing.T) {
+	tmpDir := t.TempDir()
+	pat := "ghp_" + "0123456789abcdefghijABCDEFGHIJ012345"
+
+	infoPath := filepath.Join(tmpDir, "info.json")
+	require.NoError(t, os.WriteFile(infoPath,
+		[]byte(`{"id":"sess","note":"pasted `+pat+`"}`), 0600))
+	msgPath := filepath.Join(tmpDir, "msg.json")
+	require.NoError(t, os.WriteFile(msgPath,
+		[]byte(`{"role":"user","text":"`+pat+`"}`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("opencode_session_info", infoPath)
+	idx.Add("opencode_session_message", msgPath)
+
+	registry := detector.NewRegistry()
+	registry.Register(detector.NewGitHubPATDetector())
+
+	probe := NewAIChatsProbe(models.ProbeSettings{Enabled: true}, registry)
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(findings), 2, "info + message must both surface")
+}

--- a/pkg/probe/ai_context.go
+++ b/pkg/probe/ai_context.go
@@ -64,20 +64,20 @@ func (p *ContextProbe) SetFileIndex(index *fileindex.FileIndex) {
 }
 
 // aiContextPatterns lists every file-index pattern whose matches hold
-// AI agent user-authored context. Memory files (CLAUDE.md / AGENTS.md)
-// are basename-globbed so they catch every project; command/agent/
-// skill/instruction patterns are user-level (~/.claude, ~/.codex,
-// ~/.agents) because the file index doesn't support `**` globs and
-// project-level versions would need that.
+// AI agent user-authored context. All of these are suffix-matched by
+// the file index, so each pattern catches both the user-level
+// installation (~/.claude, ~/.codex, ~/.agents) and project-level
+// equivalents at any depth — e.g. `.claude/commands/*.md` matches both
+// `~/.claude/commands/foo.md` and `~/repo/.claude/commands/foo.md`.
 var aiContextPatterns = []string{
-	"ai_memory_md",       // CLAUDE.md / AGENTS.md anywhere under home
-	"claude_commands",    // ~/.claude/commands/*.md
-	"claude_agents",      // ~/.claude/agents/*.md
-	"claude_skills",      // ~/.claude/skills/*/*.md
-	"agents_skills",      // ~/.agents/skills/*/*.md (cross-agent convention)
-	"codex_instructions", // ~/.codex/instructions.md
-	"codex_memories",     // ~/.codex/memories/*
-	"codex_skills",       // ~/.codex/skills/*/*.md
+	"ai_memory_md",       // CLAUDE.md / AGENTS.md (basename, any depth)
+	"claude_commands",    // .claude/commands/*.md (user + project)
+	"claude_agents",      // .claude/agents/*.md   (user + project)
+	"claude_skills",      // .claude/skills/*/*.md (user + project)
+	"agents_skills",      // .agents/skills/*/*.md (cross-agent convention)
+	"codex_instructions", // .codex/instructions.md
+	"codex_memories",     // .codex/memories/*
+	"codex_skills",       // .codex/skills/*/*.md
 }
 
 // Execute walks every indexed context/memory file and line-scans them

--- a/pkg/probe/ai_context.go
+++ b/pkg/probe/ai_context.go
@@ -63,8 +63,25 @@ func (p *ContextProbe) SetFileIndex(index *fileindex.FileIndex) {
 	p.fileIndex = index
 }
 
-// Execute walks every indexed CLAUDE.md / AGENTS.md (matched at any
-// depth) and line-scans them through the detector registry.
+// aiContextPatterns lists every file-index pattern whose matches hold
+// AI agent user-authored context. Memory files (CLAUDE.md / AGENTS.md)
+// are basename-globbed so they catch every project; command/agent/
+// skill/instruction patterns are user-level (~/.claude, ~/.codex,
+// ~/.agents) because the file index doesn't support `**` globs and
+// project-level versions would need that.
+var aiContextPatterns = []string{
+	"ai_memory_md",       // CLAUDE.md / AGENTS.md anywhere under home
+	"claude_commands",    // ~/.claude/commands/*.md
+	"claude_agents",      // ~/.claude/agents/*.md
+	"claude_skills",      // ~/.claude/skills/*/*.md
+	"agents_skills",      // ~/.agents/skills/*/*.md (cross-agent convention)
+	"codex_instructions", // ~/.codex/instructions.md
+	"codex_memories",     // ~/.codex/memories/*
+	"codex_skills",       // ~/.codex/skills/*/*.md
+}
+
+// Execute walks every indexed context/memory file and line-scans them
+// through the detector registry.
 func (p *ContextProbe) Execute(ctx context.Context) ([]models.Finding, error) {
 	if p.fileIndex == nil {
 		log.Ctx(ctx).Warn().
@@ -73,9 +90,16 @@ func (p *ContextProbe) Execute(ctx context.Context) ([]models.Finding, error) {
 		return nil, nil
 	}
 
+	seen := make(map[string]struct{})
 	var findings []models.Finding
-	for _, path := range p.fileIndex.Get("ai_memory_md") {
-		findings = append(findings, p.scanFile(ctx, path)...)
+	for _, pattern := range aiContextPatterns {
+		for _, path := range p.fileIndex.Get(pattern) {
+			if _, dup := seen[path]; dup {
+				continue
+			}
+			seen[path] = struct{}{}
+			findings = append(findings, p.scanFile(ctx, path)...)
+		}
 	}
 	return findings, nil
 }

--- a/pkg/probe/ai_context.go
+++ b/pkg/probe/ai_context.go
@@ -1,0 +1,101 @@
+// Copyright (C) 2026 boostsecurity.io
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package probe
+
+import (
+	"context"
+	"os"
+
+	"github.com/boostsecurityio/bagel/pkg/detector"
+	"github.com/boostsecurityio/bagel/pkg/fileindex"
+	"github.com/boostsecurityio/bagel/pkg/models"
+	"github.com/rs/zerolog/log"
+)
+
+// defaultAIContextMaxFileSize caps memory/context Markdown reads.
+// Project CLAUDE.md / AGENTS.md files are normally a few KB; anything
+// past 1 MB is most likely accidental and skipping is preferable to
+// unbounded scan.
+const defaultAIContextMaxFileSize = 1 * 1024 * 1024
+
+// ContextProbe scans AI agent context/memory files for credentials
+// users have pasted into them. CLAUDE.md (Claude Code) and AGENTS.md
+// (Codex / OpenCode / cross-tool convention) are both user-authored
+// Markdown that the agent loads as system context — secrets baked
+// into them get sent to the model on every invocation and stick
+// around in the repo history.
+//
+// Scan-only: scrub never touches these. They're user-authored docs;
+// silently rewriting them would surprise users and risk breaking
+// formatting that matters to the agent.
+type ContextProbe struct {
+	enabled          bool
+	config           models.ProbeSettings
+	detectorRegistry *detector.Registry
+	fileIndex        *fileindex.FileIndex
+	maxFileSize      int64
+}
+
+// NewContextProbe creates the AI context/memory probe.
+func NewContextProbe(config models.ProbeSettings, registry *detector.Registry) *ContextProbe {
+	return &ContextProbe{
+		enabled:          config.Enabled,
+		config:           config,
+		detectorRegistry: registry,
+		maxFileSize:      readMaxFileSizeFlag(config.Flags, defaultAIContextMaxFileSize),
+	}
+}
+
+// Name returns the probe name.
+func (p *ContextProbe) Name() string { return "ai_context" }
+
+// IsEnabled returns whether the probe is enabled.
+func (p *ContextProbe) IsEnabled() bool { return p.enabled }
+
+// SetFingerprintSalt sets the fingerprint salt on the detector registry.
+func (p *ContextProbe) SetFingerprintSalt(salt string) {
+	p.detectorRegistry.SetFingerprintSalt(salt)
+}
+
+// SetFileIndex sets the file index for this probe.
+func (p *ContextProbe) SetFileIndex(index *fileindex.FileIndex) {
+	p.fileIndex = index
+}
+
+// Execute walks every indexed CLAUDE.md / AGENTS.md (matched at any
+// depth) and line-scans them through the detector registry.
+func (p *ContextProbe) Execute(ctx context.Context) ([]models.Finding, error) {
+	if p.fileIndex == nil {
+		log.Ctx(ctx).Warn().
+			Str("probe", p.Name()).
+			Msg("File index not available, skipping ai_context probe")
+		return nil, nil
+	}
+
+	var findings []models.Finding
+	for _, path := range p.fileIndex.Get("ai_memory_md") {
+		findings = append(findings, p.scanFile(ctx, path)...)
+	}
+	return findings, nil
+}
+
+// scanFile reads one Markdown file (bounded) and runs the detector
+// registry line-by-line. Per-line scanning gives every finding a line
+// number so users can jump straight to the secret.
+func (p *ContextProbe) scanFile(ctx context.Context, path string) []models.Finding {
+	info, err := os.Stat(path)
+	if err != nil {
+		log.Ctx(ctx).Debug().Err(err).Str("file", path).Msg("Cannot stat AI context file")
+		return nil
+	}
+	if info.Size() > p.maxFileSize {
+		log.Ctx(ctx).Debug().
+			Str("file", path).
+			Int64("size_bytes", info.Size()).
+			Int64("max_size_bytes", p.maxFileSize).
+			Msg("Skipping oversized AI context file")
+		return nil
+	}
+	return scanFileLines(ctx, path, p.Name(), p.detectorRegistry, int(p.maxFileSize)+1)
+}

--- a/pkg/probe/ai_context_test.go
+++ b/pkg/probe/ai_context_test.go
@@ -126,3 +126,72 @@ func TestContextProbe_NoFileIndexReturnsNothing(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, findings)
 }
+
+func TestContextProbe_ScansAllAgentContextPatterns(t *testing.T) {
+	tmpDir := t.TempDir()
+	pat := "ghp_" + "0123456789abcdefghijABCDEFGHIJ012345"
+
+	// One file per pattern bucket. Filenames are arbitrary — the
+	// pattern key (not the filename) controls which probe input they
+	// land in.
+	cases := []struct {
+		pattern string
+		name    string
+	}{
+		{"claude_commands", "deploy.md"},
+		{"claude_agents", "tester.md"},
+		{"claude_skills", "SKILL.md"},
+		{"agents_skills", "SKILL.md"},
+		{"codex_instructions", "instructions.md"},
+		{"codex_memories", "auth.md"},
+		{"codex_skills", "SKILL.md"},
+	}
+
+	idx := fileindex.NewFileIndex()
+	for i, c := range cases {
+		// Distinct content per file so duplicate-fingerprint dedup
+		// doesn't collapse them.
+		path := filepath.Join(tmpDir, c.name+"-"+c.pattern)
+		body := "GH_TOKEN_" + c.pattern + "=" + pat + "X" + string(rune('0'+i))
+		require.NoError(t, os.WriteFile(path, []byte(body), 0600))
+		idx.Add(c.pattern, path)
+	}
+
+	probe := NewContextProbe(models.ProbeSettings{Enabled: true}, newContextRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, len(findings), len(cases),
+		"expected at least one finding per pattern bucket, got %d", len(findings))
+
+	// Every finding should be attributed to ai_context.
+	for _, f := range findings {
+		assert.Equal(t, "ai_context", f.Probe)
+	}
+}
+
+func TestContextProbe_DeduplicatesPathsAcrossPatterns(t *testing.T) {
+	tmpDir := t.TempDir()
+	pat := "ghp_" + "0123456789abcdefghijABCDEFGHIJ012345"
+	path := filepath.Join(tmpDir, "shared.md")
+	require.NoError(t, os.WriteFile(path, []byte("token="+pat), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("ai_memory_md", path)
+	idx.Add("claude_commands", path) // same path, two patterns
+
+	probe := NewContextProbe(models.ProbeSettings{Enabled: true}, newContextRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+
+	count := 0
+	for _, f := range findings {
+		if f.Metadata["token_type"] == "classic-pat" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count, "same path matched under multiple patterns must be scanned once")
+}

--- a/pkg/probe/ai_context_test.go
+++ b/pkg/probe/ai_context_test.go
@@ -1,0 +1,128 @@
+// Copyright (C) 2026 boostsecurity.io
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package probe
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/boostsecurityio/bagel/pkg/detector"
+	"github.com/boostsecurityio/bagel/pkg/fileindex"
+	"github.com/boostsecurityio/bagel/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newContextRegistry() *detector.Registry {
+	reg := detector.NewRegistry()
+	reg.Register(detector.NewGitHubPATDetector())
+	reg.Register(detector.NewSlackTokenDetector())
+	reg.Register(detector.NewGenericAPIKeyDetector())
+	return reg
+}
+
+func TestContextProbe_CatchesSecretsInProjectClaudeMD(t *testing.T) {
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "some-repo")
+	require.NoError(t, os.MkdirAll(repoDir, 0700))
+
+	pat := "ghp_" + "0123456789abcdefghijABCDEFGHIJ012345"
+	claudeMD := filepath.Join(repoDir, "CLAUDE.md")
+	require.NoError(t, os.WriteFile(claudeMD, []byte(`# Project Notes
+Use this token for the GitHub MCP server when prompted:
+
+GITHUB_TOKEN=`+pat+`
+
+Otherwise, ask the user.
+`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("ai_memory_md", claudeMD)
+
+	probe := NewContextProbe(models.ProbeSettings{Enabled: true}, newContextRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+
+	var pat_finding *models.Finding
+	for i := range findings {
+		if findings[i].Metadata["token_type"] == "classic-pat" {
+			pat_finding = &findings[i]
+		}
+	}
+	require.NotNil(t, pat_finding, "expected PAT finding from CLAUDE.md")
+	assert.Equal(t, "ai_context", pat_finding.Probe)
+	assert.NotZero(t, pat_finding.Metadata["line_number"], "line_number must be set by per-line scan")
+}
+
+func TestContextProbe_CatchesSecretsInAGENTS_MD(t *testing.T) {
+	tmpDir := t.TempDir()
+	agentsMD := filepath.Join(tmpDir, "AGENTS.md")
+	slack := "xoxb-1111111111-2222222222-aaaaaaaaaaaaaaaaaaaaaaaa"
+	require.NoError(t, os.WriteFile(agentsMD, []byte(`# Agents
+Bot token: `+slack+`
+`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("ai_memory_md", agentsMD)
+
+	probe := NewContextProbe(models.ProbeSettings{Enabled: true}, newContextRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+
+	hasSlack := false
+	for _, f := range findings {
+		if f.ID == "slack-token" {
+			hasSlack = true
+		}
+	}
+	assert.True(t, hasSlack, "expected slack-token finding from AGENTS.md")
+}
+
+func TestContextProbe_NoSecrets_NoFindings(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "CLAUDE.md")
+	require.NoError(t, os.WriteFile(path, []byte("# Project notes\n\nNothing sensitive here.\n"), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("ai_memory_md", path)
+
+	probe := NewContextProbe(models.ProbeSettings{Enabled: true}, newContextRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}
+
+func TestContextProbe_SkipsOversized(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "CLAUDE.md")
+	require.NoError(t, os.WriteFile(path, make([]byte, 4096), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("ai_memory_md", path)
+
+	probe := NewContextProbe(models.ProbeSettings{
+		Enabled: true,
+		Flags:   map[string]interface{}{"max_file_size": 1024},
+	}, newContextRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}
+
+func TestContextProbe_NoFileIndexReturnsNothing(t *testing.T) {
+	probe := NewContextProbe(models.ProbeSettings{Enabled: true}, newContextRegistry())
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}

--- a/pkg/probe/ai_mcp.go
+++ b/pkg/probe/ai_mcp.go
@@ -157,16 +157,23 @@ func (p *MCPProbe) processConfig(ctx context.Context, path string) []models.Find
 
 // scanServerEnv feeds every env value (and the legacy envVars map)
 // through the detector registry. Each detected credential carries
-// metadata locating it back to mcpServers["<name>"].env["<key>"] so
-// users can find and rotate it.
+// metadata locating it back to mcpServers["<name>"].<map>["<key>"] —
+// preserving which map (env vs envVars) the value came from, so users
+// rotate the right key.
 func (p *MCPProbe) scanServerEnv(path, serverName string, server mcpServerEntry) []models.Finding {
 	var findings []models.Finding
-	for _, envMap := range []map[string]string{server.Env, server.EnvVars} {
-		for envKey, envVal := range envMap {
+	for _, src := range []struct {
+		mapKey string
+		envMap map[string]string
+	}{
+		{"env", server.Env},
+		{"envVars", server.EnvVars},
+	} {
+		for envKey, envVal := range src.envMap {
 			if envVal == "" {
 				continue
 			}
-			location := fmt.Sprintf("mcpServers[%q].env[%q]", serverName, envKey)
+			location := fmt.Sprintf("mcpServers[%q].%s[%q]", serverName, src.mapKey, envKey)
 			detCtx := models.NewDetectionContext(models.NewDetectionContextInput{
 				Source:    "file:" + path,
 				ProbeName: p.Name(),
@@ -180,22 +187,61 @@ func (p *MCPProbe) scanServerEnv(path, serverName string, server mcpServerEntry)
 	return findings
 }
 
+// pkgRunners are the command names whose first non-flag arg is the
+// package identifier itself (e.g. `npx -y @scope/pkg ...`). We skip
+// that one arg through the registry because scope/package names look
+// suspicious to the generic-api-key detector.
+var pkgRunners = map[string]struct{}{
+	"npx":  {},
+	"bunx": {},
+	"uvx":  {},
+}
+
+// looksLikePackageIdent is a deliberately tight guard: we only skip an
+// arg if it's clearly a scoped npm package (`@scope/name[@version]`),
+// which is the dominant MCP-server publishing shape today. Unscoped
+// names ("mcp-server-foo") are short and low-entropy enough that
+// downstream detectors don't false-positive on them — and skipping
+// would risk silently dropping a real credential that happens to land
+// at the first non-flag arg.
+func looksLikePackageIdent(s string) bool {
+	if !strings.HasPrefix(s, "@") || !strings.Contains(s, "/") {
+		return false
+	}
+	// The slash must come after the scope, not at the end.
+	slash := strings.IndexByte(s, '/')
+	if slash <= 1 || slash == len(s)-1 {
+		return false
+	}
+	return true
+}
+
 // scanServerArgs feeds args strings through the registry. Some MCP
 // packages take the credential on the command line (e.g.
 // `npx -y @vendor/server --api-key XYZ`), so this catches the case
 // where the env-map path doesn't.
 func (p *MCPProbe) scanServerArgs(path, serverName string, server mcpServerEntry) []models.Finding {
 	var findings []models.Finding
-	for i, arg := range server.Args {
-		if arg == "" {
-			continue
+
+	// Compute the index of the first non-flag arg up front so the loop
+	// body stays a single pass. For pkgRunner commands, that arg is the
+	// package identifier and we skip it (only if it actually looks like
+	// one — otherwise we'd silently drop a real credential).
+	skipIdx := -1
+	if _, isRunner := pkgRunners[server.Command]; isRunner {
+		for i, a := range server.Args {
+			if strings.HasPrefix(a, "-") {
+				continue
+			}
+			if looksLikePackageIdent(a) {
+				skipIdx = i
+			}
+			break
 		}
-		// Skip the package name itself — it's the first non-flag arg
-		// of `npx`/`bunx` invocations and produces noise via the
-		// generic-api-key detector when packages have hash-like names.
-		// We still feed it to the registry if it doesn't look like a
-		// bare scope/package identifier.
-		if i == 0 && (server.Command == "npx" || server.Command == "bunx" || server.Command == "uvx") {
+	}
+
+	for i, arg := range server.Args {
+		if arg == "" || i == skipIdx {
 			continue
 		}
 		location := fmt.Sprintf("mcpServers[%q].args[%d]", serverName, i)

--- a/pkg/probe/ai_mcp.go
+++ b/pkg/probe/ai_mcp.go
@@ -1,0 +1,240 @@
+// Copyright (C) 2026 boostsecurity.io
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package probe
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/boostsecurityio/bagel/pkg/detector"
+	"github.com/boostsecurityio/bagel/pkg/fileindex"
+	"github.com/boostsecurityio/bagel/pkg/models"
+	"github.com/rs/zerolog/log"
+)
+
+// defaultMCPMaxFileSize caps each MCP-config read. claude.json grows
+// large with project history; settings files stay tiny. 4 MB is enough
+// for realistic claude.json sizes while still bounding JSON decode.
+const defaultMCPMaxFileSize = 4 * 1024 * 1024
+
+// MCPProbe extracts credentials embedded in Model Context Protocol
+// server configurations. MCP servers are launched as subprocesses by
+// AI agents (Claude Code, OpenCode, Codex, etc.); their config blocks
+// hold a `command`, `args`, and `env` map that the agent forwards to
+// the spawned process. The `env` map routinely contains third-party
+// API tokens — GitHub PATs, Slack tokens, DB connection strings — in
+// cleartext, which makes it one of the highest-value AI-side
+// credential sources today.
+//
+// Scan-only: never registered in scrub. Replacing real tokens in these
+// files with redaction markers would silently break the MCP server's
+// authentication when the agent next launches it.
+type MCPProbe struct {
+	enabled          bool
+	config           models.ProbeSettings
+	detectorRegistry *detector.Registry
+	fileIndex        *fileindex.FileIndex
+	maxFileSize      int64
+}
+
+// NewMCPProbe creates the AI MCP probe.
+func NewMCPProbe(config models.ProbeSettings, registry *detector.Registry) *MCPProbe {
+	return &MCPProbe{
+		enabled:          config.Enabled,
+		config:           config,
+		detectorRegistry: registry,
+		maxFileSize:      readMaxFileSizeFlag(config.Flags, defaultMCPMaxFileSize),
+	}
+}
+
+// Name returns the probe name.
+func (p *MCPProbe) Name() string { return "ai_mcp" }
+
+// IsEnabled returns whether the probe is enabled.
+func (p *MCPProbe) IsEnabled() bool { return p.enabled }
+
+// SetFingerprintSalt sets the fingerprint salt on the detector registry.
+func (p *MCPProbe) SetFingerprintSalt(salt string) {
+	p.detectorRegistry.SetFingerprintSalt(salt)
+}
+
+// SetFileIndex sets the file index for this probe.
+func (p *MCPProbe) SetFileIndex(index *fileindex.FileIndex) {
+	p.fileIndex = index
+}
+
+// mcpConfigPatterns lists the file-index pattern names whose matches
+// contain Claude Code MCP server config. .mcp.json is Claude's
+// project-level MCP file; settings.{,local.}json and claude.json all
+// support the mcpServers key.
+var mcpConfigPatterns = []string{
+	"claude_app_state",   // ~/.claude/claude.json
+	"claude_settings",    // ~/.claude/settings{,.local}.json + project .claude/settings.local.json
+	"mcp_project_config", // project .mcp.json
+}
+
+// Execute walks every indexed MCP config file and emits findings for
+// credentials it carries.
+func (p *MCPProbe) Execute(ctx context.Context) ([]models.Finding, error) {
+	if p.fileIndex == nil {
+		log.Ctx(ctx).Warn().
+			Str("probe", p.Name()).
+			Msg("File index not available, skipping ai_mcp probe")
+		return nil, nil
+	}
+
+	seen := make(map[string]struct{})
+	var findings []models.Finding
+	for _, pattern := range mcpConfigPatterns {
+		for _, path := range p.fileIndex.Get(pattern) {
+			if _, dup := seen[path]; dup {
+				continue
+			}
+			seen[path] = struct{}{}
+			findings = append(findings, p.processConfig(ctx, path)...)
+		}
+	}
+	return findings, nil
+}
+
+// mcpServerEntry is the minimum subset of an MCP server config we need
+// to reach credential-bearing fields. Other fields (`type`, `disabled`,
+// `cwd`, etc.) don't carry secrets and are intentionally ignored.
+type mcpServerEntry struct {
+	Command string            `json:"command"`
+	Args    []string          `json:"args"`
+	Env     map[string]string `json:"env"`
+	// Some Claude Code variants used `envVars` historically; accept it
+	// too so credentials defined that way still surface.
+	EnvVars map[string]string `json:"envVars"`
+}
+
+// mcpConfigDoc captures only the mcpServers map. claude.json carries
+// many other top-level keys (state, telemetry, etc.) — we ignore them.
+type mcpConfigDoc struct {
+	MCPServers map[string]mcpServerEntry `json:"mcpServers"`
+}
+
+// processConfig reads one MCP config file, parses it, and emits a
+// finding per credential the registry detects in env values or args.
+func (p *MCPProbe) processConfig(ctx context.Context, path string) []models.Finding {
+	info, err := os.Stat(path)
+	if err != nil {
+		log.Ctx(ctx).Debug().Err(err).Str("file", path).Msg("Cannot stat MCP config")
+		return nil
+	}
+	if info.Size() > p.maxFileSize {
+		log.Ctx(ctx).Debug().
+			Str("file", path).
+			Int64("size_bytes", info.Size()).
+			Int64("max_size_bytes", p.maxFileSize).
+			Msg("Skipping oversized MCP config")
+		return nil
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		log.Ctx(ctx).Debug().Err(err).Str("file", path).Msg("Cannot read MCP config")
+		return nil
+	}
+
+	var doc mcpConfigDoc
+	if err := json.Unmarshal(content, &doc); err != nil {
+		log.Ctx(ctx).Debug().Err(err).Str("file", path).Msg("Cannot parse MCP config JSON")
+		return nil
+	}
+
+	var findings []models.Finding
+	for name, server := range doc.MCPServers {
+		findings = append(findings, p.scanServerEnv(path, name, server)...)
+		findings = append(findings, p.scanServerArgs(path, name, server)...)
+	}
+	return findings
+}
+
+// scanServerEnv feeds every env value (and the legacy envVars map)
+// through the detector registry. Each detected credential carries
+// metadata locating it back to mcpServers["<name>"].env["<key>"] so
+// users can find and rotate it.
+func (p *MCPProbe) scanServerEnv(path, serverName string, server mcpServerEntry) []models.Finding {
+	var findings []models.Finding
+	for _, envMap := range []map[string]string{server.Env, server.EnvVars} {
+		for envKey, envVal := range envMap {
+			if envVal == "" {
+				continue
+			}
+			location := fmt.Sprintf("mcpServers[%q].env[%q]", serverName, envKey)
+			detCtx := models.NewDetectionContext(models.NewDetectionContextInput{
+				Source:    "file:" + path,
+				ProbeName: p.Name(),
+			})
+			for _, f := range p.detectorRegistry.DetectAll(envVal, detCtx) {
+				p.annotate(&f, path, serverName, server.Command, location, envKey)
+				findings = append(findings, f)
+			}
+		}
+	}
+	return findings
+}
+
+// scanServerArgs feeds args strings through the registry. Some MCP
+// packages take the credential on the command line (e.g.
+// `npx -y @vendor/server --api-key XYZ`), so this catches the case
+// where the env-map path doesn't.
+func (p *MCPProbe) scanServerArgs(path, serverName string, server mcpServerEntry) []models.Finding {
+	var findings []models.Finding
+	for i, arg := range server.Args {
+		if arg == "" {
+			continue
+		}
+		// Skip the package name itself — it's the first non-flag arg
+		// of `npx`/`bunx` invocations and produces noise via the
+		// generic-api-key detector when packages have hash-like names.
+		// We still feed it to the registry if it doesn't look like a
+		// bare scope/package identifier.
+		if i == 0 && (server.Command == "npx" || server.Command == "bunx" || server.Command == "uvx") {
+			continue
+		}
+		location := fmt.Sprintf("mcpServers[%q].args[%d]", serverName, i)
+		detCtx := models.NewDetectionContext(models.NewDetectionContextInput{
+			Source:    "file:" + path,
+			ProbeName: p.Name(),
+		})
+		for _, f := range p.detectorRegistry.DetectAll(arg, detCtx) {
+			p.annotate(&f, path, serverName, server.Command, location, "")
+			findings = append(findings, f)
+		}
+	}
+	return findings
+}
+
+// annotate attaches the MCP-server context (which server, which
+// command, where in the file) to a registry finding so users can map
+// the credential back to the agent that's using it.
+func (p *MCPProbe) annotate(
+	f *models.Finding,
+	path, serverName, serverCommand, location, envKey string,
+) {
+	if f.Metadata == nil {
+		f.Metadata = make(map[string]interface{})
+	}
+	f.Metadata["mcp_server_name"] = serverName
+	if serverCommand != "" {
+		f.Metadata["mcp_server_command"] = serverCommand
+	}
+	f.Metadata["location"] = location
+	if envKey != "" {
+		f.Metadata["env_var"] = envKey
+	}
+	// Override Path so the terminal-clickable location points at the
+	// MCP config file itself, not at any synthetic source the registry
+	// might have set.
+	f.Path = "file:" + path
+	// Keep registry findings recognizable as belonging to this probe.
+	f.Probe = p.Name()
+	// Trim trailing whitespace from Message to keep table output tidy.
+	f.Message = strings.TrimSpace(f.Message)
+}

--- a/pkg/probe/ai_mcp_test.go
+++ b/pkg/probe/ai_mcp_test.go
@@ -1,0 +1,251 @@
+// Copyright (C) 2026 boostsecurity.io
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package probe
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/boostsecurityio/bagel/pkg/detector"
+	"github.com/boostsecurityio/bagel/pkg/fileindex"
+	"github.com/boostsecurityio/bagel/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newMCPRegistry() *detector.Registry {
+	reg := detector.NewRegistry()
+	reg.Register(detector.NewGitHubPATDetector())
+	reg.Register(detector.NewSlackTokenDetector())
+	reg.Register(detector.NewDatabaseConnectionDetector())
+	reg.Register(detector.NewJWTDetector())
+	reg.Register(detector.NewGenericAPIKeyDetector())
+	return reg
+}
+
+func writeMCPConfig(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte(body), 0600))
+	return path
+}
+
+func TestMCPProbe_ExtractsGitHubPATFromEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	pat := "ghp_" + "0123456789abcdefghijABCDEFGHIJ012345"
+	path := writeMCPConfig(t, tmpDir, "claude.json", `{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {"GITHUB_PERSONAL_ACCESS_TOKEN": "`+pat+`"}
+    }
+  }
+}`)
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("claude_app_state", path)
+
+	probe := NewMCPProbe(models.ProbeSettings{Enabled: true}, newMCPRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, findings)
+
+	var pat_finding *models.Finding
+	for i := range findings {
+		if findings[i].Metadata["token_type"] == "classic-pat" {
+			pat_finding = &findings[i]
+			break
+		}
+	}
+	require.NotNil(t, pat_finding, "expected GitHub PAT finding from MCP env, got: %+v", findings)
+	assert.Equal(t, "github", pat_finding.Metadata["mcp_server_name"])
+	assert.Equal(t, "npx", pat_finding.Metadata["mcp_server_command"])
+	assert.Equal(t, "GITHUB_PERSONAL_ACCESS_TOKEN", pat_finding.Metadata["env_var"])
+	assert.Contains(t, pat_finding.Metadata["location"], `mcpServers["github"].env["GITHUB_PERSONAL_ACCESS_TOKEN"]`)
+	assert.Equal(t, "file:"+path, pat_finding.Path)
+	assert.Equal(t, "ai_mcp", pat_finding.Probe)
+}
+
+func TestMCPProbe_ExtractsSlackTokenFromArgs(t *testing.T) {
+	tmpDir := t.TempDir()
+	slack := "xoxb-1111111111-2222222222-aaaaaaaaaaaaaaaaaaaaaaaa"
+	path := writeMCPConfig(t, tmpDir, "settings.json", `{
+  "mcpServers": {
+    "slack": {
+      "command": "/usr/local/bin/my-mcp-server",
+      "args": ["--token", "`+slack+`"]
+    }
+  }
+}`)
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("claude_settings", path)
+
+	probe := NewMCPProbe(models.ProbeSettings{Enabled: true}, newMCPRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, findings)
+
+	var slackFinding *models.Finding
+	for i := range findings {
+		if findings[i].ID == "slack-token" {
+			slackFinding = &findings[i]
+			break
+		}
+	}
+	require.NotNil(t, slackFinding, "expected slack-token finding")
+	assert.Equal(t, "slack", slackFinding.Metadata["mcp_server_name"])
+	assert.Contains(t, slackFinding.Metadata["location"], `mcpServers["slack"].args[1]`)
+}
+
+func TestMCPProbe_SkipsPackageNameFirstArg(t *testing.T) {
+	// `@modelcontextprotocol/server-x` looks suspicious to generic
+	// API-key detector heuristics; skipping the first arg when the
+	// command is npx/bunx/uvx prevents that noise.
+	tmpDir := t.TempDir()
+	path := writeMCPConfig(t, tmpDir, ".mcp.json", `{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["@modelcontextprotocol/server-filesystem", "/some/path"]
+    }
+  }
+}`)
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("mcp_project_config", path)
+
+	probe := NewMCPProbe(models.ProbeSettings{Enabled: true}, newMCPRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, findings, "no credential present — must not emit findings")
+}
+
+func TestMCPProbe_HandlesLegacyEnvVarsKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	pat := "ghp_" + "9876543210zyxwvutsrqponmlkjihgfedcba"
+	path := writeMCPConfig(t, tmpDir, "claude.json", `{
+  "mcpServers": {
+    "legacy": {
+      "command": "node",
+      "args": ["server.js"],
+      "envVars": {"GITHUB_TOKEN": "`+pat+`"}
+    }
+  }
+}`)
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("claude_app_state", path)
+
+	probe := NewMCPProbe(models.ProbeSettings{Enabled: true}, newMCPRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, findings)
+
+	hasPAT := false
+	for _, f := range findings {
+		if f.Metadata["token_type"] == "classic-pat" {
+			hasPAT = true
+			assert.Equal(t, "GITHUB_TOKEN", f.Metadata["env_var"])
+		}
+	}
+	assert.True(t, hasPAT)
+}
+
+func TestMCPProbe_NoMCPServers_NoFindings(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := writeMCPConfig(t, tmpDir, "claude.json", `{
+  "numStartups": 42,
+  "userID": "abc",
+  "otherStuff": "unrelated"
+}`)
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("claude_app_state", path)
+
+	probe := NewMCPProbe(models.ProbeSettings{Enabled: true}, newMCPRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}
+
+func TestMCPProbe_DeduplicatesPathsAcrossPatterns(t *testing.T) {
+	tmpDir := t.TempDir()
+	pat := "ghp_" + "0123456789abcdefghijABCDEFGHIJ012345"
+	path := writeMCPConfig(t, tmpDir, "claude.json", `{
+  "mcpServers": {"x": {"command":"node","env":{"K":"`+pat+`"}}}
+}`)
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("claude_app_state", path)
+	idx.Add("claude_settings", path) // same path indexed twice
+
+	probe := NewMCPProbe(models.ProbeSettings{Enabled: true}, newMCPRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+
+	patCount := 0
+	for _, f := range findings {
+		if f.Metadata["token_type"] == "classic-pat" {
+			patCount++
+		}
+	}
+	assert.Equal(t, 1, patCount, "same path indexed under multiple patterns must be parsed once")
+}
+
+func TestMCPProbe_MalformedJSONReturnsNoError(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := writeMCPConfig(t, tmpDir, "claude.json", `{not json`)
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("claude_app_state", path)
+
+	probe := NewMCPProbe(models.ProbeSettings{Enabled: true}, newMCPRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}
+
+func TestMCPProbe_OversizedSkipped(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "claude.json")
+	require.NoError(t, os.WriteFile(path, make([]byte, 4096), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("claude_app_state", path)
+
+	probe := NewMCPProbe(models.ProbeSettings{
+		Enabled: true,
+		Flags:   map[string]interface{}{"max_file_size": 1024},
+	}, newMCPRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}
+
+func TestMCPProbe_NoFileIndexReturnsNothing(t *testing.T) {
+	probe := NewMCPProbe(models.ProbeSettings{Enabled: true}, newMCPRegistry())
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}

--- a/pkg/probe/ai_mcp_test.go
+++ b/pkg/probe/ai_mcp_test.go
@@ -131,6 +131,66 @@ func TestMCPProbe_SkipsPackageNameFirstArg(t *testing.T) {
 	assert.Empty(t, findings, "no credential present — must not emit findings")
 }
 
+func TestMCPProbe_SkipsPackageNameAfterFlags(t *testing.T) {
+	// The canonical npx invocation is `npx -y @scope/pkg ...` — args[0]
+	// is `-y`, args[1] is the package. Skipping only args[0] would feed
+	// the package name to the generic-api-key detector. The fix is to
+	// skip the first non-flag arg, which here is index 1.
+	tmpDir := t.TempDir()
+	path := writeMCPConfig(t, tmpDir, ".mcp.json", `{
+  "mcpServers": {
+    "fs": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/some/path"]
+    }
+  }
+}`)
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("mcp_project_config", path)
+
+	probe := NewMCPProbe(models.ProbeSettings{Enabled: true}, newMCPRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, findings, "package identifier at args[1] (after -y) must be skipped")
+}
+
+func TestMCPProbe_DoesNotSkipFirstArgWhenItIsNotAPackageIdent(t *testing.T) {
+	// Defensive: if the first non-flag arg looks like a credential
+	// (e.g. someone wired their token at the start of the args list),
+	// don't silently swallow it just because the command is npx.
+	tmpDir := t.TempDir()
+	pat := "ghp_" + "0123456789abcdefghijABCDEFGHIJ012345"
+	path := writeMCPConfig(t, tmpDir, ".mcp.json", `{
+  "mcpServers": {
+    "weird": {
+      "command": "npx",
+      "args": ["`+pat+`", "/some/path"]
+    }
+  }
+}`)
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("mcp_project_config", path)
+
+	probe := NewMCPProbe(models.ProbeSettings{Enabled: true}, newMCPRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+
+	hasPAT := false
+	for _, f := range findings {
+		if f.Metadata["token_type"] == "classic-pat" {
+			hasPAT = true
+			break
+		}
+	}
+	assert.True(t, hasPAT, "PAT-shaped first arg must not be skipped")
+}
+
 func TestMCPProbe_HandlesLegacyEnvVarsKey(t *testing.T) {
 	tmpDir := t.TempDir()
 	pat := "ghp_" + "9876543210zyxwvutsrqponmlkjihgfedcba"
@@ -159,6 +219,12 @@ func TestMCPProbe_HandlesLegacyEnvVarsKey(t *testing.T) {
 		if f.Metadata["token_type"] == "classic-pat" {
 			hasPAT = true
 			assert.Equal(t, "GITHUB_TOKEN", f.Metadata["env_var"])
+			// Location must reflect the actual source map — the legacy
+			// `envVars` key — not `env`, or users will rotate the
+			// wrong path.
+			assert.Contains(t, f.Metadata["location"],
+				`mcpServers["legacy"].envVars["GITHUB_TOKEN"]`,
+				"legacy envVars findings must be attributed to envVars[…], not env[…]")
 		}
 	}
 	assert.True(t, hasPAT)


### PR DESCRIPTION
> Stacked on `feat/iacProbe` (PR #52); landing PR #51 → PR #52 first will rebase this clean.

## Summary

Three additions and one fileindex change, all aimed at the AI-side credential surfaces that have grown fastest in the last year.

### New probe — `ai_mcp` (`pkg/probe/ai_mcp.go`)

Extracts credentials from Model Context Protocol server configurations. MCP servers are subprocesses spawned by AI agents (Claude Code, OpenCode, Codex…); the config block holds a `command`, `args`, and `env` map the agent forwards to the spawned process. The `env` map routinely contains third-party API tokens — GitHub PATs, Slack tokens, DB connection strings — in cleartext.

- Reads `mcpServers["<name>"].env` and `.envVars` (legacy Claude variant), and `.args`.
- Feeds every value through the shared detector registry, then annotates findings with `mcp_server_name`, `mcp_server_command`, `env_var`, and a structured `location` (e.g. `mcpServers[\"github\"].env[\"GITHUB_PERSONAL_ACCESS_TOKEN\"]`).
- Skips the first `args[0]` when the command is `npx` / `bunx` / `uvx` so the bare package identifier (`@modelcontextprotocol/server-…`) doesn't produce generic-API-key noise.
- Dedupes paths reached via multiple file-index patterns (`claude_app_state` + `claude_settings` + `mcp_project_config`).
- **Scan-only**: deliberately not registered in scrub — rewriting these files with redaction markers would break the MCP server's auth on next launch.

### New probe — `ai_context` (`pkg/probe/ai_context.go`)

Line-scans user-authored Markdown that AI agents load as system context. Secrets pasted into these get sent to the model on every invocation and stick around in git history.

Covers:

- `CLAUDE.md` / `AGENTS.md` (basename match anywhere — per-repo + global)
- `.claude/commands/*.md`, `.claude/agents/*.md`, `.claude/skills/*/*.md`
- `.agents/skills/*/*.md` (cross-agent skill convention)
- `.codex/instructions.md`, `.codex/memories/*`, `.codex/skills/*/*.md`

Dedupes paths across overlapping patterns. **Scan-only** — won't rewrite user-authored docs.

### File index: wildcard-glob suffix matching (`pkg/fileindex/fileindex.go`)

`compilePattern`'s glob branch now suffix-matches the last N+1 segments (N = slash count in pattern), matching the same shape the literal-path branch already used. This is what lets a pattern like `.claude/commands/*.md` catch both `~/.claude/commands/foo.md` and `~/projects/repo/.claude/commands/foo.md` without callers enumerating every project depth. New test `TestPatternMatching_WildcardSuffix` locks the behavior in (covers home-root match, project-depth matches, and the negative cases — wrong segment count, wrong extension).

### `ai_chats` extension — REPL, paste cache, session env, OpenCode storage (`pkg/probe/ai_chats.go`)

Adds six more file-index patterns to the existing `ai_chats` probe's coverage. All are append-only or replaceable surfaces, so scrubbing them is safe (worst case: a replay shows `[REDACTED-…]` instead of the original secret, which is the desired outcome).

- `claude_repl_history` (`~/.claude/history.jsonl`)
- `claude_paste_cache` (`~/.claude/paste-cache/*`)
- `claude_session_env` (`~/.claude/session-env/*`)
- `codex_repl_history` (`~/.codex/history.jsonl`)
- `opencode_session_info` (`~/.local/share/opencode/storage/session/info/*.json`)
- `opencode_session_message` (`~/.local/share/opencode/storage/session/message/*/*.json`)

## Test plan

- [x] `go test ./pkg/probe/... ./pkg/fileindex/...` — covers env+args extraction, legacy `envVars` key, `npx`/`bunx`/`uvx` first-arg skip, malformed JSON, oversized-file skip, path dedup, and per-pattern detection for every new `ai_chats` / `ai_context` bucket
- [x] `TestPatternMatching_WildcardSuffix` locks in home-level + project-depth glob matching with negative cases
- [x] `golangci-lint run` and `go vet ./...` pass
- [x] Manual smoke: run `bagel scan` on a workstation with active Claude Code / Codex / OpenCode installs and a project `.mcp.json`, confirm `mcp_server_name` and `location` metadata correctly point at the credential