### PR TITLE
Expand credential file coverage: cloud caches, SaaS CLIs, forges, AI MCP, IaC

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -236,6 +236,10 @@ func setDefaults(v *viper.Viper) {
 		{"name": "railway_config", "patterns": []string{".railway/config.json"}, "type": "glob"},
 		{"name": "snowflake_config", "patterns": []string{".snowflake/connections.toml"}, "type": "glob"},
 		{"name": "doppler_config", "patterns": []string{".doppler.yaml"}, "type": "glob"},
+		{"name": "gh_hosts", "patterns": []string{".config/gh/hosts.yml"}, "type": "glob"},
+		{"name": "glab_config", "patterns": []string{".config/glab-cli/config.yml"}, "type": "glob"},
+		{"name": "hub_config", "patterns": []string{".config/hub"}, "type": "glob"},
+		{"name": "netrc_file", "patterns": []string{".netrc", "_netrc"}, "type": "glob"},
 
 		// Docker
 		{"name": "docker_config", "patterns": []string{".docker/config.json"}, "type": "glob"},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -267,6 +267,17 @@ func setDefaults(v *viper.Viper) {
 		// Podman / containers — same schema as docker config.json, different path.
 		{"name": "podman_config", "patterns": []string{".config/containers/auth.json"}, "type": "glob"},
 
+		// Helm OCI registry auth — `helm registry login` writes a
+		// docker-config-shaped JSON here. Same `auths{<host>.auth}`
+		// blob with base64(user:password) that DockerProbe already knows how to parse.
+		{"name": "helm_oci_registry", "patterns": []string{".config/helm/registry/config.json"}, "type": "glob"},
+
+		// Docker context TLS material — client cert + key + CA for
+		// connecting to a remote Docker daemon. Only the key.pem is a
+		// secret; cert.pem and ca.pem start with `BEGIN CERTIFICATE`
+		// which the SSH-private-key detector ignores by design.
+		{"name": "docker_context_keys", "patterns": []string{".docker/contexts/tls/*/*/*.pem"}, "type": "glob"},
+
 		// Kubernetes
 		{"name": "kubeconfig", "patterns": []string{".kube/config"}, "type": "glob"},
 
@@ -274,7 +285,8 @@ func setDefaults(v *viper.Viper) {
 		{"name": "bashrc", "patterns": []string{".bashrc", ".bash_profile", ".profile"}, "type": "glob"},
 		{"name": "zshrc", "patterns": []string{".zshrc", ".zprofile"}, "type": "glob"},
 
-		// Shell history files - Unix shells and PowerShell (Windows)
+		// Shell history files - Unix shells and PowerShell (Windows).
+		// Also covers DB and language-REPL input history.
 		{"name": "shell_history", "patterns": []string{
 			".bash_history",
 			".zsh_history",
@@ -283,6 +295,13 @@ func setDefaults(v *viper.Viper) {
 			".local/share/fish/fish_history",
 			// PowerShell history (Windows)
 			"AppData/Roaming/Microsoft/Windows/PowerShell/PSReadLine/ConsoleHost_history.txt",
+			// DB / language REPL histories
+			".psql_history",
+			".mysql_history",
+			".sqlite_history",
+			".python_history",
+			".node_repl_history",
+			".irb_history",
 		}, "type": "glob"},
 
 		// Environment files

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -178,6 +178,8 @@ func setDefaults(v *viper.Viper) {
 		// AWS
 		{"name": "aws_config", "patterns": []string{".aws/config"}, "type": "glob"},
 		{"name": "aws_credentials", "patterns": []string{".aws/credentials"}, "type": "glob"},
+		{"name": "aws_sso_cache", "patterns": []string{".aws/sso/cache/*.json"}, "type": "glob"},
+		{"name": "aws_cli_cache", "patterns": []string{".aws/cli/cache/*.json"}, "type": "glob"},
 
 		// Google Cloud (GCP) - Unix: ~/.config/gcloud, Windows: %APPDATA%\gcloud
 		{"name": "gcp_config", "patterns": []string{
@@ -211,6 +213,29 @@ func setDefaults(v *viper.Viper) {
 			"AppData/Roaming/.azure/clouds.config",
 			"AppData/Roaming/.azure/azureProfile.json",
 		}, "type": "glob"},
+		{"name": "azure_tokens", "patterns": []string{
+			".azure/accessTokens.json",
+			".azure/msal_token_cache.*",
+			".azure/msazure.login/*",
+			".azure/azd/*",
+			"AppData/Roaming/.azure/accessTokens.json",
+			"AppData/Roaming/.azure/msal_token_cache.*",
+		}, "type": "glob"},
+		{"name": "oci_config", "patterns": []string{
+			".oci/config",
+			".oci/sessions/*",
+		}, "type": "glob"},
+		{"name": "aliyun_config", "patterns": []string{".aliyun/config.json"}, "type": "glob"},
+		{"name": "bluemix_config", "patterns": []string{".bluemix/config.json"}, "type": "glob"},
+		{"name": "doctl_config", "patterns": []string{".config/doctl/config.yaml"}, "type": "glob"},
+		{"name": "hcloud_config", "patterns": []string{".config/hcloud/cli.toml"}, "type": "glob"},
+		{"name": "scw_config", "patterns": []string{".config/scw/config.yaml"}, "type": "glob"},
+		{"name": "linode_config", "patterns": []string{".config/linode-cli/*"}, "type": "glob"},
+		{"name": "fly_config", "patterns": []string{".fly/config.yml"}, "type": "glob"},
+		{"name": "vercel_config", "patterns": []string{".vercel/auth.json"}, "type": "glob"},
+		{"name": "railway_config", "patterns": []string{".railway/config.json"}, "type": "glob"},
+		{"name": "snowflake_config", "patterns": []string{".snowflake/connections.toml"}, "type": "glob"},
+		{"name": "doppler_config", "patterns": []string{".doppler.yaml"}, "type": "glob"},
 
 		// Docker
 		{"name": "docker_config", "patterns": []string{".docker/config.json"}, "type": "glob"},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -241,6 +241,26 @@ func setDefaults(v *viper.Viper) {
 		{"name": "hub_config", "patterns": []string{".config/hub"}, "type": "glob"},
 		{"name": "netrc_file", "patterns": []string{".netrc", "_netrc"}, "type": "glob"},
 
+		// Kiro IDE MCP — same shape as Claude Code's mcpServers; suffix
+		// matching catches both user (~/.kiro/) and project (<repo>/.kiro/) forms.
+		{"name": "kiro_mcp", "patterns": []string{".kiro/settings/mcp.json"}, "type": "glob"},
+
+		// Salesforce CLIs. .sf is the newer CLI's auth store;
+		// .sfdx/auth/* is the legacy layout. Both hold OAuth refresh tokens.
+		{"name": "sf_config", "patterns": []string{".sf/*"}, "type": "glob"},
+		{"name": "sfdx_config", "patterns": []string{".sfdx/*", ".sfdx/auth/*"}, "type": "glob"},
+
+		// Ansible — top-level files (galaxy_token, vault_password*).
+		// The cp/ socket dir and tmp/ subdirs aren't credentials and
+		// produce no findings on a registry pass.
+		{"name": "ansible_config", "patterns": []string{".ansible/*"}, "type": "glob"},
+
+		// Rails / WordPress DB config — project-level files holding
+		// cleartext DB passwords. Suffix matching catches them at any
+		// repo depth without anchoring to home root.
+		{"name": "rails_database_yml", "patterns": []string{"config/database.yml"}, "type": "glob"},
+		{"name": "wp_config", "patterns": []string{"wp-config.php"}, "type": "glob"},
+
 		// Docker
 		{"name": "docker_config", "patterns": []string{".docker/config.json"}, "type": "glob"},
 

--- a/pkg/probe/ai_mcp.go
+++ b/pkg/probe/ai_mcp.go
@@ -68,13 +68,15 @@ func (p *MCPProbe) SetFileIndex(index *fileindex.FileIndex) {
 }
 
 // mcpConfigPatterns lists the file-index pattern names whose matches
-// contain Claude Code MCP server config. .mcp.json is Claude's
-// project-level MCP file; settings.{,local.}json and claude.json all
-// support the mcpServers key.
+// contain MCP server config. Claude Code splits configs across
+// claude.json, settings.{,local.}json, and .mcp.json; Kiro IDE uses
+// its own .kiro/settings/mcp.json. All share the same `mcpServers`
+// JSON schema, so the same parser handles every entry.
 var mcpConfigPatterns = []string{
 	"claude_app_state",   // ~/.claude/claude.json
 	"claude_settings",    // ~/.claude/settings{,.local}.json + project .claude/settings.local.json
 	"mcp_project_config", // project .mcp.json
+	"kiro_mcp",           // ~/.kiro/settings/mcp.json + project .kiro/settings/mcp.json
 }
 
 // Execute walks every indexed MCP config file and emits findings for

--- a/pkg/probe/ai_mcp_test.go
+++ b/pkg/probe/ai_mcp_test.go
@@ -315,3 +315,40 @@ func TestMCPProbe_NoFileIndexReturnsNothing(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, findings)
 }
+
+func TestMCPProbe_KiroIDE_ExtractsGitHubPATFromEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	pat := "ghp_" + "0123456789abcdefghijABCDEFGHIJ012345"
+	path := writeMCPConfig(t, tmpDir, "mcp.json", `{
+  "mcpServers": {
+    "github": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "env": {"GITHUB_PERSONAL_ACCESS_TOKEN": "`+pat+`"}
+    }
+  }
+}`)
+
+	// Kiro's pattern key is distinct from Claude's; the test confirms
+	// the ai_mcp probe routes Kiro files through the same parser.
+	idx := fileindex.NewFileIndex()
+	idx.Add("kiro_mcp", path)
+
+	probe := NewMCPProbe(models.ProbeSettings{Enabled: true}, newMCPRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, findings)
+
+	var pat_finding *models.Finding
+	for i := range findings {
+		if findings[i].Metadata["token_type"] == "classic-pat" {
+			pat_finding = &findings[i]
+			break
+		}
+	}
+	require.NotNil(t, pat_finding, "Kiro MCP must reuse the Claude MCP parser")
+	assert.Equal(t, "github", pat_finding.Metadata["mcp_server_name"])
+	assert.Equal(t, "GITHUB_PERSONAL_ACCESS_TOKEN", pat_finding.Metadata["env_var"])
+}

--- a/pkg/probe/cloud.go
+++ b/pkg/probe/cloud.go
@@ -5,7 +5,9 @@ package probe
 
 import (
 	"context"
+	"encoding/json"
 	"os"
+	"time"
 
 	"github.com/boostsecurityio/bagel/pkg/detector"
 	"github.com/boostsecurityio/bagel/pkg/fileindex"
@@ -50,6 +52,41 @@ func (p *CloudProbe) SetFileIndex(index *fileindex.FileIndex) {
 	p.fileIndex = index
 }
 
+// cloudCredentialPatterns lists every file-index pattern whose matches
+// hold cloud-provider or SaaS-CLI credentials.
+var cloudCredentialPatterns = []string{
+	// AWS
+	"aws_config",
+	"aws_credentials",
+	"aws_sso_cache",
+	"aws_cli_cache",
+
+	// Azure
+	"azure_config",
+	"azure_tokens",
+
+	// GCP
+	"gcp_config",
+	"gcp_credentials",
+
+	// HashiCorp Vault
+	"vault_token",
+
+	// Single-vendor cloud / SaaS CLIs (Phase D-1).
+	"oci_config",
+	"aliyun_config",
+	"bluemix_config",
+	"doctl_config",
+	"hcloud_config",
+	"scw_config",
+	"linode_config",
+	"fly_config",
+	"vercel_config",
+	"railway_config",
+	"snowflake_config",
+	"doppler_config",
+}
+
 // Execute runs the cloud probe
 func (p *CloudProbe) Execute(ctx context.Context) ([]models.Finding, error) {
 	var findings []models.Finding
@@ -62,55 +99,31 @@ func (p *CloudProbe) Execute(ctx context.Context) ([]models.Finding, error) {
 		return findings, nil
 	}
 
-	// Get cloud credential files from file index
-	awsConfig := p.fileIndex.Get("aws_config")
-	awsCredentials := p.fileIndex.Get("aws_credentials")
-	gcpConfig := p.fileIndex.Get("gcp_config")
-	gcpCredentials := p.fileIndex.Get("gcp_credentials")
-	azureConfig := p.fileIndex.Get("azure_config")
-
-	vaultTokenFiles := p.fileIndex.Get("vault_token")
+	seen := make(map[string]struct{})
+	for _, pattern := range cloudCredentialPatterns {
+		for _, filePath := range p.fileIndex.Get(pattern) {
+			if _, dup := seen[filePath]; dup {
+				continue
+			}
+			seen[filePath] = struct{}{}
+			// AWS SSO + CLI caches are rewritten on each `aws sso
+			// login` / `aws sts assume-role` and old files linger on
+			// disk indefinitely. Skip when the embedded expiry has
+			// passed so we don't surface dead credentials as findings.
+			if isAWSCachePattern(pattern) && awsCacheExpired(filePath) {
+				log.Ctx(ctx).Debug().
+					Str("file", filePath).
+					Str("pattern", pattern).
+					Msg("Skipping expired AWS credential cache")
+				continue
+			}
+			findings = append(findings, p.processCloudFile(ctx, filePath)...)
+		}
+	}
 
 	log.Ctx(ctx).Debug().
-		Int("aws_config_count", len(awsConfig)).
-		Int("aws_credentials_count", len(awsCredentials)).
-		Int("gcp_config_count", len(gcpConfig)).
-		Int("gcp_credentials_count", len(gcpCredentials)).
-		Int("azure_config_count", len(azureConfig)).
-		Int("vault_token_count", len(vaultTokenFiles)).
-		Msg("Found cloud credential files")
-
-	// Process AWS files
-	for _, filePath := range awsConfig {
-		fileFindings := p.processCloudFile(ctx, filePath)
-		findings = append(findings, fileFindings...)
-	}
-	for _, filePath := range awsCredentials {
-		fileFindings := p.processCloudFile(ctx, filePath)
-		findings = append(findings, fileFindings...)
-	}
-
-	// Process GCP files
-	for _, filePath := range gcpConfig {
-		fileFindings := p.processCloudFile(ctx, filePath)
-		findings = append(findings, fileFindings...)
-	}
-	for _, filePath := range gcpCredentials {
-		fileFindings := p.processCloudFile(ctx, filePath)
-		findings = append(findings, fileFindings...)
-	}
-
-	// Process Azure files
-	for _, filePath := range azureConfig {
-		fileFindings := p.processCloudFile(ctx, filePath)
-		findings = append(findings, fileFindings...)
-	}
-
-	// Process Vault token file
-	for _, filePath := range vaultTokenFiles {
-		fileFindings := p.processCloudFile(ctx, filePath)
-		findings = append(findings, fileFindings...)
-	}
+		Int("cloud_files_scanned", len(seen)).
+		Msg("Cloud probe completed")
 
 	// Check for Kubernetes service account token (system path, outside home dir)
 	findings = append(findings, p.checkK8sServiceAccountToken(ctx)...)
@@ -155,4 +168,59 @@ func (p *CloudProbe) checkK8sServiceAccountToken(ctx context.Context) []models.F
 // works for both and lets findings carry a line number.
 func (p *CloudProbe) processCloudFile(ctx context.Context, filePath string) []models.Finding {
 	return scanFileLines(ctx, filePath, p.Name(), p.detectorRegistry, 0)
+}
+
+// isAWSCachePattern returns true for the two AWS file-index patterns
+// whose contents are credential caches with an embedded expiry.
+func isAWSCachePattern(pattern string) bool {
+	return pattern == "aws_sso_cache" || pattern == "aws_cli_cache"
+}
+
+// awsCacheExpiryGrace covers clock skew between the local machine and
+// AWS at the moment the cache was written. Keeping the grace small
+// avoids re-reporting almost-expired tokens; one minute is enough to
+// absorb realistic skew without making us report dead tokens for long.
+const awsCacheExpiryGrace = time.Minute
+
+// awsCacheExpired returns true when the AWS SSO or CLI cache file at
+// path has already passed its embedded expiry. The CLI cache wraps
+// credentials in `{"Credentials":{"Expiration":"<rfc3339>"}}` (sts
+// assume-role / get-credentials shape); the SSO cache uses a
+// top-level `expiresAt`. Either field signals when the cached token
+// stops authenticating.
+//
+// We err toward reporting on any parse / read / time-format error:
+// when we can't tell whether the cache is dead, we still surface it.
+// This keeps the false-negative rate low while killing the dominant
+// false-positive source (long-stale caches sitting on disk).
+func awsCacheExpired(path string) bool {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var doc struct {
+		// AWS CLI cache (sts assume-role output / GetSessionToken).
+		Credentials *struct {
+			Expiration string `json:"Expiration"`
+		} `json:"Credentials"`
+		// AWS SSO cache.
+		ExpiresAt string `json:"expiresAt"`
+	}
+	if err := json.Unmarshal(content, &doc); err != nil {
+		return false
+	}
+	expiryStr := ""
+	switch {
+	case doc.Credentials != nil && doc.Credentials.Expiration != "":
+		expiryStr = doc.Credentials.Expiration
+	case doc.ExpiresAt != "":
+		expiryStr = doc.ExpiresAt
+	default:
+		return false
+	}
+	t, err := time.Parse(time.RFC3339, expiryStr)
+	if err != nil {
+		return false
+	}
+	return time.Now().UTC().After(t.Add(awsCacheExpiryGrace))
 }

--- a/pkg/probe/cloud.go
+++ b/pkg/probe/cloud.go
@@ -15,7 +15,8 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-// CloudProbe checks cloud provider credential files
+// CloudProbe scans cloud provider, SaaS CLI, and code-forge auth
+// files for embedded credentials.
 type CloudProbe struct {
 	enabled          bool
 	config           models.ProbeSettings
@@ -85,6 +86,10 @@ var cloudCredentialPatterns = []string{
 	"railway_config",
 	"snowflake_config",
 	"doppler_config",
+	"gh_hosts",
+	"glab_config",
+	"hub_config",
+	"netrc_file",
 }
 
 // Execute runs the cloud probe

--- a/pkg/probe/cloud.go
+++ b/pkg/probe/cloud.go
@@ -90,6 +90,13 @@ var cloudCredentialPatterns = []string{
 	"glab_config",
 	"hub_config",
 	"netrc_file",
+
+	// SaaS CRM + automation + DB-app configs (Phase D-3).
+	"sf_config",          // Salesforce SF CLI auth
+	"sfdx_config",        // Salesforce sfdx (legacy) auth
+	"ansible_config",     // ~/.ansible/* — galaxy_token, vault_password*
+	"rails_database_yml", // <repo>/config/database.yml — DB passwords
+	"wp_config",          // <repo>/wp-config.php — WP keys + DB password
 }
 
 // Execute runs the cloud probe

--- a/pkg/probe/cloud.go
+++ b/pkg/probe/cloud.go
@@ -97,6 +97,11 @@ var cloudCredentialPatterns = []string{
 	"ansible_config",     // ~/.ansible/* — galaxy_token, vault_password*
 	"rails_database_yml", // <repo>/config/database.yml — DB passwords
 	"wp_config",          // <repo>/wp-config.php — WP keys + DB password
+
+	// Docker context TLS keys (Phase D-5). cert.pem / ca.pem are public
+	// (BEGIN CERTIFICATE) and the SSH-private-key detector ignores them;
+	// key.pem (BEGIN PRIVATE KEY) is the real secret and matches.
+	"docker_context_keys",
 }
 
 // Execute runs the cloud probe
@@ -127,6 +132,13 @@ func (p *CloudProbe) Execute(ctx context.Context) ([]models.Finding, error) {
 					Str("file", filePath).
 					Str("pattern", pattern).
 					Msg("Skipping expired AWS credential cache")
+				continue
+			}
+			// PEM private-key files need whole-file scanning — the
+			// SSH-private-key detector matches the BEGIN…END envelope
+			// which line-by-line scanning splits across calls.
+			if isPEMFilePattern(pattern) {
+				findings = append(findings, p.processPEMFile(ctx, filePath)...)
 				continue
 			}
 			findings = append(findings, p.processCloudFile(ctx, filePath)...)
@@ -186,6 +198,29 @@ func (p *CloudProbe) processCloudFile(ctx context.Context, filePath string) []mo
 // whose contents are credential caches with an embedded expiry.
 func isAWSCachePattern(pattern string) bool {
 	return pattern == "aws_sso_cache" || pattern == "aws_cli_cache"
+}
+
+// isPEMFilePattern returns true for patterns whose matches hold PEM
+// blocks (BEGIN…END) that the detector needs to see in one piece.
+// Per-line scanning would split the envelope across calls and the
+// SSH-private-key detector would never fire.
+func isPEMFilePattern(pattern string) bool {
+	return pattern == "docker_context_keys"
+}
+
+// processPEMFile reads a file whole and runs the registry against the
+// full content. Used for patterns flagged by isPEMFilePattern.
+func (p *CloudProbe) processPEMFile(ctx context.Context, filePath string) []models.Finding {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		log.Ctx(ctx).Debug().Err(err).Str("file", filePath).Msg("Cannot read PEM file")
+		return nil
+	}
+	detCtx := models.NewDetectionContext(models.NewDetectionContextInput{
+		Source:    "file:" + filePath,
+		ProbeName: p.Name(),
+	})
+	return p.detectorRegistry.DetectAll(string(content), detCtx)
 }
 
 // awsCacheExpiryGrace covers clock skew between the local machine and

--- a/pkg/probe/cloud_test.go
+++ b/pkg/probe/cloud_test.go
@@ -568,6 +568,111 @@ func TestCloudProbe_AWS_Cache_MalformedFile_StillScanned(t *testing.T) {
 	assert.NotEmpty(t, findings, "malformed cache file must still be scanned")
 }
 
+// Phase D-2: code-forge CLI auth files + .netrc. These follow the same
+// "scan home-dir credential file via registry" pattern as the cloud
+// CLIs — coverage just expanded beyond cloud providers.
+
+func TestCloudProbe_GH_HostsYML_GitHubOAuth(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "hosts.yml")
+	// Realistic gh hosts.yml shape with a gho_ OAuth token.
+	require.NoError(t, os.WriteFile(path, []byte(`github.com:
+    user: amfortin
+    oauth_token: gho_0123456789abcdefghijABCDEFGHIJ012345
+    git_protocol: https
+`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("gh_hosts", path)
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, newD1Registry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+
+	hasOAuth := false
+	for _, f := range findings {
+		if f.Metadata["token_type"] == "oauth-token" {
+			hasOAuth = true
+		}
+	}
+	assert.True(t, hasOAuth, "gho_ OAuth token in hosts.yml must surface as oauth-token")
+}
+
+func TestCloudProbe_GlabConfig_GitLabPAT(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "config.yml")
+	require.NoError(t, os.WriteFile(path, []byte(`hosts:
+    gitlab.com:
+        token: glpat-AbCdEfGhIjKlMnOpQrSt
+        api_protocol: https
+`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("glab_config", path)
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, newD1Registry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.NotEmpty(t, findings, "glab token must be surfaced (via generic-api-key)")
+}
+
+func TestCloudProbe_HubConfig_OAuthToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "hub")
+	// hub stores a 40-char hex token; older format but still in use.
+	require.NoError(t, os.WriteFile(path, []byte(`github.com:
+- user: amfortin
+  oauth_token: 0123456789abcdef0123456789abcdef01234567
+  protocol: https
+`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("hub_config", path)
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, newD1Registry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.NotEmpty(t, findings, "hub oauth_token must be surfaced (via generic-api-key)")
+}
+
+func TestCloudProbe_Netrc_PasswordLine(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, ".netrc")
+	// machine/login/password is the canonical .netrc shape; the
+	// password is what we care about.
+	require.NoError(t, os.WriteFile(path, []byte(`machine github.com
+  login amfortin
+  password ghp_0123456789abcdefghijABCDEFGHIJ012345
+
+machine api.example.com
+  login deploy-bot
+  password hunter2-supersecret-token-value-123
+`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("netrc_file", path)
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, newD1Registry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+
+	hasPAT := false
+	for _, f := range findings {
+		if f.Metadata["token_type"] == "classic-pat" {
+			hasPAT = true
+		}
+	}
+	assert.True(t, hasPAT, "ghp_ token stashed as .netrc password must classify as classic-pat")
+}
+
 func TestCloudProbe_DeduplicatesPathsAcrossPatterns(t *testing.T) {
 	tmpDir := t.TempDir()
 	path := filepath.Join(tmpDir, "shared")

--- a/pkg/probe/cloud_test.go
+++ b/pkg/probe/cloud_test.go
@@ -774,6 +774,62 @@ define('AUTH_KEY', 'random-string-here-with-enough-entropy-to-trigger-detection'
 	assert.NotEmpty(t, findings, "wp-config.php DB_PASSWORD must surface via generic-api-key")
 }
 
+// Phase D-5: Docker contexts ship TLS material for remote daemons —
+// the key.pem is a real client certificate's private key. cert.pem and
+// ca.pem are public certificates and produce no findings, as expected.
+
+func TestCloudProbe_DockerContext_PrivateKeyDetected(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "key.pem")
+	// Realistic-looking unencrypted PKCS8 private key block — the
+	// SSH-private-key detector's regex matches any
+	// `-----BEGIN ... PRIVATE KEY-----` envelope, including non-SSH ones.
+	pem := "-----BEGIN PRIVATE KEY-----\n" +
+		"MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQ" +
+		"DemoFakeKeyMaterialForTestUseOnlyAbsolutelyNotARealKey" +
+		"\n-----END PRIVATE KEY-----\n"
+	require.NoError(t, os.WriteFile(path, []byte(pem), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("docker_context_keys", path)
+
+	r := detector.NewRegistry()
+	r.Register(detector.NewSSHPrivateKeyDetector())
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, r)
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, findings, "Docker context key.pem must surface as a PEM private key")
+	assert.Equal(t, "ssh-private-key-pkcs8", findings[0].ID)
+}
+
+func TestCloudProbe_DockerContext_PublicCertSilent(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "cert.pem")
+	// Public certificate — BEGIN CERTIFICATE, not BEGIN PRIVATE KEY.
+	// The SSH-private-key detector deliberately ignores this so we
+	// don't spam findings for every public cert on disk.
+	pem := "-----BEGIN CERTIFICATE-----\n" +
+		"MIIDazCCAlOgAwIBAgIUExampleCertificateBodyNotARealCertificateContent" +
+		"\n-----END CERTIFICATE-----\n"
+	require.NoError(t, os.WriteFile(path, []byte(pem), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("docker_context_keys", path)
+
+	r := detector.NewRegistry()
+	r.Register(detector.NewSSHPrivateKeyDetector())
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, r)
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, findings, "public cert.pem must not produce findings")
+}
+
 func TestCloudProbe_DeduplicatesPathsAcrossPatterns(t *testing.T) {
 	tmpDir := t.TempDir()
 	path := filepath.Join(tmpDir, "shared")

--- a/pkg/probe/cloud_test.go
+++ b/pkg/probe/cloud_test.go
@@ -673,6 +673,107 @@ machine api.example.com
 	assert.True(t, hasPAT, "ghp_ token stashed as .netrc password must classify as classic-pat")
 }
 
+// Phase D-3: Salesforce + Ansible + Rails/WordPress.
+
+func TestCloudProbe_Salesforce_SF_AuthJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	// SF CLI stashes one JSON file per org alias; the access/refresh
+	// tokens are top-level string fields.
+	path := filepath.Join(tmpDir, "prod-org.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{
+"orgId":"00D000000000000",
+"username":"admin@example.com",
+"accessToken":"00D000000000000!ARSAQA1234567890ABCDEFGHIJKLMNOPQRSTUVWX",
+"refreshToken":"5Aep861234567890ABCDEFGHIJKLMNOPQRSTUVWX"
+}`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("sf_config", path)
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, newD1Registry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.NotEmpty(t, findings, "SF auth JSON must surface its tokens")
+}
+
+func TestCloudProbe_Ansible_GalaxyToken(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "galaxy_token")
+	// galaxy_token is a single line: `token: <40+ chars>`. Value must
+	// avoid the generic-api-key detector's "obvious placeholder"
+	// exclusion list (^xxx|yyy|zzz|abc|123) — real Ansible tokens
+	// look like random hex.
+	require.NoError(t, os.WriteFile(path,
+		[]byte("token: e7f9c1d4b3a2e8f6c5d7b9a1e3f5c7d9b1a3e5f7\n"), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("ansible_config", path)
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, newD1Registry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.NotEmpty(t, findings, "Ansible galaxy_token must surface")
+}
+
+func TestCloudProbe_Rails_DatabaseYML_DBConnectionString(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "database.yml")
+	// Real Rails configs commonly carry a `url:` with the full DB
+	// connection string — the DB-conn-string detector classifies it
+	// specifically rather than relying on generic-api-key.
+	require.NoError(t, os.WriteFile(path, []byte(`production:
+  adapter: postgresql
+  url: postgres://app:hunter2-supersecret@db.example.com:5432/myapp
+`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("rails_database_yml", path)
+
+	r := detector.NewRegistry()
+	r.Register(detector.NewDatabaseConnectionDetector())
+	r.Register(detector.NewGenericAPIKeyDetector())
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, r)
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+
+	hasDB := false
+	for _, f := range findings {
+		if f.ID == "database-connection-string" {
+			hasDB = true
+			assert.Equal(t, "postgres", f.Metadata["scheme"])
+		}
+	}
+	assert.True(t, hasDB, "Rails database.yml URL must classify as database-connection-string")
+}
+
+func TestCloudProbe_WordPress_WpConfig_DBPassword(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "wp-config.php")
+	require.NoError(t, os.WriteFile(path, []byte(`<?php
+define('DB_NAME', 'wordpress');
+define('DB_USER', 'wpuser');
+define('DB_PASSWORD', 'hunter2-supersecret-database-pw');
+define('AUTH_KEY', 'random-string-here-with-enough-entropy-to-trigger-detection');
+`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("wp_config", path)
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, newD1Registry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.NotEmpty(t, findings, "wp-config.php DB_PASSWORD must surface via generic-api-key")
+}
+
 func TestCloudProbe_DeduplicatesPathsAcrossPatterns(t *testing.T) {
 	tmpDir := t.TempDir()
 	path := filepath.Join(tmpDir, "shared")

--- a/pkg/probe/cloud_test.go
+++ b/pkg/probe/cloud_test.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/boostsecurityio/bagel/pkg/detector"
 	"github.com/boostsecurityio/bagel/pkg/fileindex"
@@ -343,4 +345,249 @@ func TestCloudProbe_UnreadableFile(t *testing.T) {
 	require.NoError(t, err)
 	// Note: depending on permissions, we might get findings or not
 	// The key is that it doesn't crash
+}
+
+// Phase D-1: cloud / SaaS CLI round-up. The probe consumes a single
+// shared pattern slice (cloudCredentialPatterns); these tests lock
+// in the slice membership by inserting one credential-bearing file
+// per vendor pattern and asserting the registry picks it up.
+
+func newD1Registry() *detector.Registry {
+	r := detector.NewRegistry()
+	r.Register(detector.NewCloudCredentialsDetector())
+	r.Register(detector.NewJWTDetector())
+	r.Register(detector.NewGitHubPATDetector())
+	r.Register(detector.NewGenericAPIKeyDetector())
+	return r
+}
+
+func TestCloudProbe_AWS_SSO_Cache(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "11aabbccdd.json")
+	// Realistic SSO cache shape: accessToken is the secret, the rest is metadata.
+	require.NoError(t, os.WriteFile(path, []byte(`{
+"startUrl":"https://example.awsapps.com/start",
+"accessToken":"aoatJ.veryLongSSOAccessTokenWithEnoughCharsToHitGenericKeyDetector",
+"expiresAt":"2099-01-01T00:00:00Z"
+}`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("aws_sso_cache", path)
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, newD1Registry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, findings, "SSO cache accessToken must be picked up by the registry")
+}
+
+func TestCloudProbe_Azure_Tokens(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "accessTokens.json")
+	// Single-line JWT in a JSON value — JWT detector must fire.
+	pat := "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9hYWFhYWFhYS1hYWFhLWFhYWEtYWFhYS1hYWFhYWFhYWFhYWEvIn0.signaturepartlongenoughtomatch"
+	require.NoError(t, os.WriteFile(path, []byte(`[{"accessToken":"`+pat+`"}]`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("azure_tokens", path)
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, newD1Registry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	require.NotEmpty(t, findings)
+	// JWT subtype enrichment should classify it as Azure AD.
+	hasAzure := false
+	for _, f := range findings {
+		if f.Metadata["token_subtype"] == "jwt-azure-ad" {
+			hasAzure = true
+		}
+	}
+	assert.True(t, hasAzure, "Azure AD JWT subtype must be set on the finding")
+}
+
+func TestCloudProbe_VendorCLIs_AllPatternsHit(t *testing.T) {
+	tmpDir := t.TempDir()
+	// One credential-bearing file per single-vendor pattern. Body uses
+	// an AWS-shaped access key — the most universally-recognized secret
+	// shape — so we don't depend on per-vendor detectors that don't
+	// exist yet. The point is that the file is reached and scanned.
+	akia := "AKIAIOSFODNN7EXAMPLE"
+	cases := []struct {
+		pattern string
+		body    string
+	}{
+		{"oci_config", "[DEFAULT]\nkey=" + akia + "\n"},
+		{"aliyun_config", `{"profiles":[{"access_key_id":"` + akia + `"}]}`},
+		{"bluemix_config", `{"IAMToken":"` + akia + `"}`},
+		{"doctl_config", "access-token: " + akia + "\n"},
+		{"hcloud_config", "token = \"" + akia + "\"\n"},
+		{"scw_config", "secret_key: " + akia + "\n"},
+		{"linode_config", "token=" + akia + "\n"},
+		{"fly_config", "access_token: " + akia + "\n"},
+		{"vercel_config", `{"token":"` + akia + `"}`},
+		{"railway_config", `{"token":"` + akia + `"}`},
+		{"snowflake_config", "password = \"" + akia + "\"\n"},
+		{"doppler_config", "token: " + akia + "\n"},
+	}
+
+	idx := fileindex.NewFileIndex()
+	for i, c := range cases {
+		path := filepath.Join(tmpDir, c.pattern+strconv.Itoa(i))
+		require.NoError(t, os.WriteFile(path, []byte(c.body), 0600))
+		idx.Add(c.pattern, path)
+	}
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, newD1Registry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+
+	hit := 0
+	for _, f := range findings {
+		if f.ID == "cloud-credential-aws-access-key-id" {
+			hit++
+		}
+	}
+	assert.Equal(t, len(cases), hit,
+		"each vendor pattern must produce at least one cloud-credential finding (got %d of %d)",
+		hit, len(cases))
+}
+
+// Expired AWS SSO / CLI cache files are the dominant source of false
+// positives for those two patterns — the files sit on disk long after
+// the embedded credential is dead. The probe pre-checks expiry and
+// skips dead files entirely; these tests lock that behavior in.
+
+func TestCloudProbe_AWS_CLI_Cache_Expired_Skipped(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "expired.json")
+	// 16 months ago — well past any reasonable session lifetime.
+	require.NoError(t, os.WriteFile(path, []byte(`{
+"Credentials": {
+  "AccessKeyId": "ASIAIOSFODNN7EXAMPLE",
+  "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+  "SessionToken": "IQoJb3JpZ2luX2VjStillExampleNoLongerValid",
+  "Expiration": "2025-01-21T09:42:24Z"
+}}`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("aws_cli_cache", path)
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, newD1Registry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, findings, "expired CLI cache must not produce findings")
+}
+
+func TestCloudProbe_AWS_CLI_Cache_Fresh_Reported(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "fresh.json")
+	future := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	require.NoError(t, os.WriteFile(path, []byte(`{
+"Credentials": {
+  "AccessKeyId": "ASIAIOSFODNN7EXAMPLE",
+  "SecretAccessKey": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+  "Expiration": "`+future+`"
+}}`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("aws_cli_cache", path)
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, newD1Registry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.NotEmpty(t, findings, "live CLI cache must be reported")
+}
+
+func TestCloudProbe_AWS_SSO_Cache_Expired_Skipped(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "sso-expired.json")
+	require.NoError(t, os.WriteFile(path, []byte(`{
+"startUrl":"https://example.awsapps.com/start",
+"accessToken":"aoatJ.veryLongSSOAccessTokenWithEnoughCharsToHitGenericKeyDetector",
+"expiresAt":"2025-01-01T00:00:00Z"
+}`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("aws_sso_cache", path)
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, newD1Registry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, findings, "expired SSO cache must not produce findings")
+}
+
+func TestCloudProbe_AWS_SSO_Cache_Fresh_Reported(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "sso-fresh.json")
+	future := time.Now().UTC().Add(time.Hour).Format(time.RFC3339)
+	require.NoError(t, os.WriteFile(path, []byte(`{
+"startUrl":"https://example.awsapps.com/start",
+"accessToken":"aoatJ.veryLongSSOAccessTokenWithEnoughCharsToHitGenericKeyDetector",
+"expiresAt":"`+future+`"
+}`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("aws_sso_cache", path)
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, newD1Registry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.NotEmpty(t, findings, "live SSO cache must be reported")
+}
+
+func TestCloudProbe_AWS_Cache_MalformedFile_StillScanned(t *testing.T) {
+	// When we can't tell whether the cache is expired (bad JSON, missing
+	// expiry field, etc.) we err toward reporting — better a noisy
+	// finding the user can dismiss than silently dropping a live token.
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "malformed.json")
+	require.NoError(t, os.WriteFile(path,
+		[]byte(`AccessKeyId=AKIAIOSFODNN7EXAMPLE`), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("aws_cli_cache", path)
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, newD1Registry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.NotEmpty(t, findings, "malformed cache file must still be scanned")
+}
+
+func TestCloudProbe_DeduplicatesPathsAcrossPatterns(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "shared")
+	require.NoError(t, os.WriteFile(path, []byte("key=AKIAIOSFODNN7EXAMPLE\n"), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("aws_credentials", path)
+	idx.Add("oci_config", path) // same path under two patterns
+
+	probe := NewCloudProbe(models.ProbeSettings{Enabled: true}, newD1Registry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+
+	hit := 0
+	for _, f := range findings {
+		if f.ID == "cloud-credential-aws-access-key-id" {
+			hit++
+		}
+	}
+	assert.Equal(t, 1, hit, "same path indexed under multiple patterns must be scanned once")
 }

--- a/pkg/probe/docker.go
+++ b/pkg/probe/docker.go
@@ -73,6 +73,7 @@ func (p *DockerProbe) Execute(ctx context.Context) ([]models.Finding, error) {
 	}{
 		{"docker_config", "docker"},
 		{"podman_config", "podman"},
+		{"helm_oci_registry", "helm"},
 	} {
 		for _, path := range p.fileIndex.Get(src.patternName) {
 			findings = append(findings, p.processConfig(ctx, path, src.runtime)...)

--- a/pkg/probe/docker_test.go
+++ b/pkg/probe/docker_test.go
@@ -173,3 +173,33 @@ func TestDockerProbe_DisabledByConfig(t *testing.T) {
 	probe := NewDockerProbe(models.ProbeSettings{Enabled: false}, newDockerRegistry())
 	assert.False(t, probe.IsEnabled())
 }
+
+func TestDockerProbe_HelmOCIRegistry_InlineAuth(t *testing.T) {
+	// Helm's OCI registry config uses the same JSON shape as Docker's
+	// config.json — the existing auths parser handles it; this test
+	// confirms the helm_oci_registry pattern is wired into the probe's
+	// source list and that the runtime metadata is `helm`.
+	tmpDir := t.TempDir()
+	encoded := base64.StdEncoding.EncodeToString([]byte("helmbot:hunter2"))
+	path := writeDockerConfig(t, tmpDir, `{
+  "auths": {
+    "registry.example.com": {"auth": "`+encoded+`"}
+  }
+}`)
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("helm_oci_registry", path)
+
+	probe := NewDockerProbe(models.ProbeSettings{Enabled: true}, newDockerRegistry())
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	require.Len(t, findings, 1)
+
+	f := findings[0]
+	assert.Equal(t, "docker-registry-inline-auth", f.ID)
+	assert.Equal(t, "helm", f.Metadata["runtime"])
+	assert.Equal(t, "registry.example.com", f.Metadata["registry_host"])
+	assert.Equal(t, "helmbot", f.Metadata["username"])
+}

--- a/pkg/probe/kube.go
+++ b/pkg/probe/kube.go
@@ -7,7 +7,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"runtime"
 	"strings"
@@ -131,10 +133,14 @@ func (p *KubeProbe) collectKubeconfigPaths(ctx context.Context) []string {
 	}
 
 	// System kubeconfigs — direct stat. processKubeconfig handles the
-	// non-existent / unreadable cases gracefully.
+	// unreadable cases gracefully (logs + skips), so we only filter
+	// out paths that definitively do not exist. Stat errors other
+	// than ErrNotExist (e.g. EACCES from a hardened parent directory)
+	// still get appended so the read attempt's permission error
+	// reaches the user-visible log.
 	if runtime.GOOS != "windows" {
 		for _, sysPath := range systemKubeconfigPaths {
-			if _, err := os.Stat(sysPath); err == nil {
+			if _, err := os.Stat(sysPath); err == nil || !errors.Is(err, fs.ErrNotExist) {
 				paths = append(paths, sysPath)
 			}
 		}

--- a/pkg/probe/kube.go
+++ b/pkg/probe/kube.go
@@ -89,9 +89,22 @@ func (p *KubeProbe) Execute(ctx context.Context) ([]models.Finding, error) {
 	return findings, nil
 }
 
+// systemKubeconfigPaths are admin/system kubeconfig files outside
+// $HOME that the file index won't reach. We stat each on every probe
+// run and feed any that exist through the same kubeconfig path. These
+// are typically root-owned (k3s, kubeadm); a non-root scan will get a
+// permission error on read and log+skip, which is the correct outcome.
+//
+// Declared as a var so tests can override.
+var systemKubeconfigPaths = []string{
+	"/etc/rancher/k3s/k3s.yaml",  // k3s admin kubeconfig
+	"/etc/kubernetes/admin.conf", // kubeadm cluster-admin kubeconfig
+}
+
 // collectKubeconfigPaths gathers candidate kubeconfig file paths from
-// both the file index (~/.kube/config matches) and the KUBECONFIG env
-// var, which often points at non-home paths (e.g. /etc/rancher/k3s/k3s.yaml).
+// the file index (~/.kube/config matches), the KUBECONFIG env var
+// (which often points at non-home paths), and a small set of well-known
+// system kubeconfig paths outside home that the file index can't reach.
 func (p *KubeProbe) collectKubeconfigPaths(ctx context.Context) []string {
 	var paths []string
 
@@ -116,6 +129,17 @@ func (p *KubeProbe) collectKubeconfigPaths(ctx context.Context) []string {
 			paths = append(paths, p)
 		}
 	}
+
+	// System kubeconfigs — direct stat. processKubeconfig handles the
+	// non-existent / unreadable cases gracefully.
+	if runtime.GOOS != "windows" {
+		for _, sysPath := range systemKubeconfigPaths {
+			if _, err := os.Stat(sysPath); err == nil {
+				paths = append(paths, sysPath)
+			}
+		}
+	}
+
 	return paths
 }
 

--- a/pkg/probe/kube_test.go
+++ b/pkg/probe/kube_test.go
@@ -197,7 +197,58 @@ func TestKubeProbe_SkipsOversizedKubeconfig(t *testing.T) {
 
 func TestKubeProbe_NoFileIndexAndNoEnvReturnsNothing(t *testing.T) {
 	t.Setenv("KUBECONFIG", "")
+	// Zero out system paths for the duration so the test passes on
+	// machines that have /etc/rancher/k3s/k3s.yaml present.
+	orig := systemKubeconfigPaths
+	t.Cleanup(func() { systemKubeconfigPaths = orig })
+	systemKubeconfigPaths = nil
+
 	probe := NewKubeProbe(models.ProbeSettings{Enabled: true}, newKubeRegistry())
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, findings)
+}
+
+func TestKubeProbe_SystemKubeconfigPathScannedWhenPresent(t *testing.T) {
+	// Stand in for /etc/rancher/k3s/k3s.yaml — we redirect the
+	// system-path list at a tmp file we can actually write.
+	tmpDir := t.TempDir()
+	sysPath := filepath.Join(tmpDir, "k3s.yaml")
+	token := makeK8sSAToken(t)
+	require.NoError(t, os.WriteFile(sysPath, []byte(
+		"users:\n- name: admin\n  user:\n    token: "+token+"\n",
+	), 0600))
+
+	orig := systemKubeconfigPaths
+	t.Cleanup(func() { systemKubeconfigPaths = orig })
+	systemKubeconfigPaths = []string{sysPath}
+
+	t.Setenv("KUBECONFIG", "")
+	probe := NewKubeProbe(models.ProbeSettings{Enabled: true}, newKubeRegistry())
+	probe.SetFileIndex(fileindex.NewFileIndex()) // no kubeconfig pattern entries
+
+	findings, err := probe.Execute(context.Background())
+	require.NoError(t, err)
+
+	var jwt *models.Finding
+	for i := range findings {
+		if findings[i].ID == "jwt-jwt-token" {
+			jwt = &findings[i]
+		}
+	}
+	require.NotNil(t, jwt, "system kubeconfig must be stat'd + scanned without a file-index hit")
+	assert.Equal(t, "jwt-kubernetes-service-account", jwt.Metadata["token_subtype"])
+}
+
+func TestKubeProbe_SystemKubeconfigMissingNoError(t *testing.T) {
+	orig := systemKubeconfigPaths
+	t.Cleanup(func() { systemKubeconfigPaths = orig })
+	systemKubeconfigPaths = []string{"/nonexistent/path/should-not-exist.yaml"}
+
+	t.Setenv("KUBECONFIG", "")
+	probe := NewKubeProbe(models.ProbeSettings{Enabled: true}, newKubeRegistry())
+	probe.SetFileIndex(fileindex.NewFileIndex())
+
 	findings, err := probe.Execute(context.Background())
 	require.NoError(t, err)
 	assert.Empty(t, findings)

--- a/pkg/probe/kube_test.go
+++ b/pkg/probe/kube_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/boostsecurityio/bagel/pkg/detector"
@@ -210,6 +211,12 @@ func TestKubeProbe_NoFileIndexAndNoEnvReturnsNothing(t *testing.T) {
 }
 
 func TestKubeProbe_SystemKubeconfigPathScannedWhenPresent(t *testing.T) {
+	// The probe's system-path loop is Unix-only (k3s + kubeadm don't
+	// ship Windows builds), so this test has no behavior to exercise
+	// on Windows runners.
+	if runtime.GOOS == "windows" {
+		t.Skip("system kubeconfig stat is Unix-only")
+	}
 	// Stand in for /etc/rancher/k3s/k3s.yaml — we redirect the
 	// system-path list at a tmp file we can actually write.
 	tmpDir := t.TempDir()
@@ -241,6 +248,9 @@ func TestKubeProbe_SystemKubeconfigPathScannedWhenPresent(t *testing.T) {
 }
 
 func TestKubeProbe_SystemKubeconfigMissingNoError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("system kubeconfig stat is Unix-only")
+	}
 	orig := systemKubeconfigPaths
 	t.Cleanup(func() { systemKubeconfigPaths = orig })
 	systemKubeconfigPaths = []string{"/nonexistent/path/should-not-exist.yaml"}

--- a/pkg/probe/shell_history_test.go
+++ b/pkg/probe/shell_history_test.go
@@ -555,3 +555,78 @@ func TestShellHistoryProbe_ZshHistoryParsing(t *testing.T) {
 	assert.True(t, findingIDs["github-token-classic-pat"], "Should detect GitHub PAT tokens")
 	assert.True(t, findingIDs["npm-token-npm-auth-token"], "Should detect NPM token")
 }
+
+// D-4: DB REPL + language REPL history files all route through the
+// shell_history pattern and the existing probe. The probe code didn't
+// change — these tests lock in that the new pattern entries surface
+// pasted credentials.
+
+func TestShellHistoryProbe_DetectsSecretsInPsqlHistory(t *testing.T) {
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+
+	// .psql_history typical content: SQL typed at the psql prompt.
+	// `\c <conn-string>` and ALTER USER … PASSWORD are the classic
+	// ways credentials end up in this file.
+	path := filepath.Join(tmpDir, ".psql_history")
+	body := `SELECT * FROM users;
+\c postgres://app:hunter2-supersecret@db.example.com:5432/myapp
+ALTER USER app WITH PASSWORD 'PgPr0dQuiteLongPassWord';
+`
+	require.NoError(t, os.WriteFile(path, []byte(body), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("shell_history", path)
+
+	r := detector.NewRegistry()
+	r.Register(detector.NewDatabaseConnectionDetector())
+	r.Register(detector.NewGenericAPIKeyDetector())
+
+	probe := NewShellHistoryProbe(models.ProbeSettings{Enabled: true}, r)
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(ctx)
+	require.NoError(t, err)
+
+	hasDBConn := false
+	for _, f := range findings {
+		if f.ID == "database-connection-string" {
+			hasDBConn = true
+			assert.Equal(t, "postgres", f.Metadata["scheme"])
+		}
+	}
+	assert.True(t, hasDBConn, `psql \c with embedded password must classify as database-connection-string`)
+}
+
+func TestShellHistoryProbe_DetectsSecretsInPythonHistory(t *testing.T) {
+	tmpDir := t.TempDir()
+	ctx := context.Background()
+
+	pat := "ghp_" + "0123456789abcdefghijABCDEFGHIJ012345"
+	path := filepath.Join(tmpDir, ".python_history")
+	body := `import os
+os.environ["GITHUB_TOKEN"] = "` + pat + `"
+print("hi")
+`
+	require.NoError(t, os.WriteFile(path, []byte(body), 0600))
+
+	idx := fileindex.NewFileIndex()
+	idx.Add("shell_history", path)
+
+	r := detector.NewRegistry()
+	r.Register(detector.NewGitHubPATDetector())
+
+	probe := NewShellHistoryProbe(models.ProbeSettings{Enabled: true}, r)
+	probe.SetFileIndex(idx)
+
+	findings, err := probe.Execute(ctx)
+	require.NoError(t, err)
+
+	hasPAT := false
+	for _, f := range findings {
+		if f.Metadata["token_type"] == "classic-pat" {
+			hasPAT = true
+		}
+	}
+	assert.True(t, hasPAT, "GitHub PAT pasted into Python REPL must surface as classic-pat")
+}


### PR DESCRIPTION
## Summary

Expands credential-file coverage across cloud, SaaS, AI agent, and
DevOps tooling. No new detectors — every new file is line-scanned
through the existing registry, so embedded tokens / JWTs / keys
surface with their real classification.

### New coverage

**Cloud + live token caches**
- AWS SSO + STS caches: `.aws/sso/cache/*.json`, `.aws/cli/cache/*.json`
- Azure live tokens: `accessTokens.json`, `msal_token_cache.*`, `msazure.login/*`, `azd/*`

**Single-vendor cloud / SaaS CLIs**
- OCI, Alibaba, IBM Bluemix, DigitalOcean (doctl), Hetzner, Scaleway,
  Linode, Fly.io, Vercel, Railway, Snowflake, Doppler

**Code-forge auth + general HTTP creds**
- `~/.config/gh/hosts.yml`, `~/.config/glab-cli/config.yml`, `~/.config/hub`
- `~/.netrc`, `~/_netrc`

**AI agent MCP**
- `.kiro/settings/mcp.json` (user + project) — same MCP schema as Claude

**SaaS / automation / DB-app configs**
- Salesforce: `~/.sf/*`, `~/.sfdx/*`, `~/.sfdx/auth/*`
- Ansible: `~/.ansible/*` (galaxy_token, vault_password*)
- Rails `config/database.yml` and WordPress `wp-config.php` at any repo depth

**Containers + IaC**
- Helm OCI registry: `~/.config/helm/registry/config.json` (routed
  through DockerProbe — same `auths{}` schema; metadata `runtime: helm`)
- Docker context TLS keys: `~/.docker/contexts/tls/*/*/*.pem`
- System kubeconfigs (Unix only): `/etc/rancher/k3s/k3s.yaml`,
  `/etc/kubernetes/admin.conf`

**DB / language REPL history**
- `.psql_history`, `.mysql_history`, `.sqlite_history`,
  `.python_history`, `.node_repl_history`, `.irb_history`

### Behavioral changes

- **AWS cache expiry filter** — `.aws/sso/cache/*.json` and
  `.aws/cli/cache/*.json` are pre-checked for embedded expiry
  (`Credentials.Expiration` / `expiresAt`). Past-expiry entries are
  skipped to kill the dominant false-positive source (stale caches
  sitting on disk after `aws sso login`). 1-minute grace for clock skew;
  errs toward reporting on parse / format failure.
- **CloudProbe** refactored to a single shared pattern slice with path
  dedup — adding a new vendor is a one-line change.
- **CloudProbe** dispatches PEM-bearing patterns to whole-file scanning
  so `BEGIN PRIVATE KEY` blocks match (line-scan splits the envelope).
- **DockerProbe** gained a third `runtime` entry (`helm`) reusing the
  existing `auths{}` parser.